### PR TITLE
Change geq -> leq in docs

### DIFF
--- a/doc/representation.rst
+++ b/doc/representation.rst
@@ -15,7 +15,7 @@ For instance, consider the 2-dimensional polyhedron described by the following H
 
 .. math::
 
-   x_1 + x_2 &\geq 1 \\
+   x_1 + x_2 &\leq 1 \\
    x_1 - x_2 &\leq 0 \\
    x_1 & \geq 0.
 


### PR DESCRIPTION
Wrong inequality to generate the polyhedron that is discussed and built.

Changes \geq to \leq in line 18