### PR TITLE
change bitwise not to logical not

### DIFF
--- a/src/liftedrep.jl
+++ b/src/liftedrep.jl
@@ -9,7 +9,7 @@ mutable struct LiftedHRepresentation{N, T} <: HRepresentation{N, T}
     linset::IntSet
 
     function LiftedHRepresentation{N, T}(A::AbstractMatrix, linset::IntSet=IntSet()) where {N, T}
-        if ~isempty(linset) && last(linset) > size(A, 1)
+        if !isempty(linset) && last(linset) > size(A, 1)
             error("The elements of linset should be between 1 and the number of rows of A")
         end
         if size(A, 2) != N+1
@@ -102,7 +102,7 @@ mutable struct LiftedVRepresentation{N,T} <: VRepresentation{N,T}
         if length(R) > 0 && size(R, 2) != N+1
             error("dimension does not match")
         end
-        if ~isempty(linset) && last(linset) > size(R, 1)
+        if !isempty(linset) && last(linset) > size(R, 1)
             error("The elements of linset should be between 1 and the number of rows of R")
         end
         new{N, T}(R, linset)

--- a/src/simplerep.jl
+++ b/src/simplerep.jl
@@ -13,7 +13,7 @@ mutable struct SimpleHRepresentation{N, T} <: HRepresentation{N, T}
         if size(A, 1) != length(b)
             error("The length of b must be equal to the number of rows of A")
         end
-        if ~isempty(linset) && last(linset) > length(b)
+        if !isempty(linset) && last(linset) > length(b)
             error("The elements of linset should be between 1 and the number of rows of A/length of b")
         end
         if size(A, 2) != N
@@ -119,10 +119,10 @@ mutable struct SimpleVRepresentation{N,T} <: VRepresentation{N,T}
         if (length(R) > 0 && size(R, 2) != N) || (length(V) > 0 && size(V, 2) != N)
             error("dimension does not match")
         end
-        if ~isempty(Vlinset) && last(Vlinset) > size(V, 1)
+        if !isempty(Vlinset) && last(Vlinset) > size(V, 1)
             error("The elements of Vlinset should be between 1 and the number of rows of V")
         end
-        if ~isempty(Rlinset) && last(Rlinset) > size(R, 1)
+        if !isempty(Rlinset) && last(Rlinset) > size(R, 1)
             error("The elements of Rlinset should be between 1 and the number of rows of R")
         end
         new{N, T}(V, R, Vlinset, Rlinset)


### PR DESCRIPTION
This change is pretty inconsequential since `~b === !b`for `b::Bool` (as far as I know), but I think the intention is to use logical negation as opposed to bitwise negation.