### PR TITLE
Don't bounds-error on empty polygon

### DIFF
--- a/src/recipe.jl
+++ b/src/recipe.jl
@@ -2,6 +2,9 @@ using RecipesBase
 
 function getsemihull(ps::Vector{PT}, sign_sense, counterclockwise, yray = nothing) where PT
     hull = PT[]
+    if length(ps) == 0
+        return hull
+    end
     prev = sign_sense == 1 ? first(ps) : last(ps)
     cur = prev
     for j in (sign_sense == 1 ? (2:length(ps)) : ((length(ps)-1):-1:1))


### PR DESCRIPTION
It still errors in Plots due to https://github.com/JuliaPlots/Plots.jl/issues/1329, but maybe that can get fixed.

I'm not sure if there's a way to return something that means "do nothing" from the recipe.