### PR TITLE
HRep * A -> A \ HRep

### DIFF
--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -8,6 +8,9 @@ removehredundancy!
 
 ## Operations
 ```@docs
+*
+\
+/
 intersect
 convexhull
 ```

--- a/src/Polyhedra.jl
+++ b/src/Polyhedra.jl
@@ -10,7 +10,7 @@ export PolyhedraLibrary, Polyhedron, getlibrary, getlibraryfor
 abstract type PolyhedraLibrary end
 abstract type Polyhedron{N,T} <: GeometryPrimitive{N,T} end
 
-import Base.intersect, Base.==, Base.+, Base.*, Base.isempty, Base.copy, Base.push!, Base.length, Base.eltype, Base.start, Base.done, Base.next
+import Base: intersect, ==, +, *, \, /, isempty, copy, push!, length, eltype, start, done, next
 
 # Definitions
 include("elements.jl")

--- a/src/elements.jl
+++ b/src/elements.jl
@@ -69,10 +69,10 @@ islin(v::HyperPlane) = true
 (*)(h::HalfSpace, α::Real) = HalfSpace(h.a * α, h.β * α)
 (*)(α::Real, h::HalfSpace) = HalfSpace(α * h.a, α * h.β)
 
-function (*)(h::ElemT, P::Matrix) where ElemT<:HRepElement
+function (/)(h::ElemT, P::Matrix) where ElemT<:HRepElement
     Tout = mypromote_type(eltype(ElemT), eltype(P))
     ElemTout = changeboth(ElemT, size(P, 2), Tout)
-    ElemTout(P' * h.a, h.β)
+    ElemTout(P * h.a, h.β)
 end
 function zeropad(h::ElemT, n::Integer) where ElemT<:HRepElement
     if n == 0

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -65,7 +65,7 @@ function project(p::Polyhedron{N,T}, P::AbstractMatrix) where {N,T}
         end
         basis = [Q R]
     end
-    eliminate(p * basis, IntSet(m+1:N))
+    eliminate(basis \ p, IntSet(m+1:N))
 end
 
 _fixelim(h::ElemT, I, J, v) where {ElemT<:HRepElement} = ElemT(h.a[J], h.β - dot(h.a[I], v))

--- a/src/repop.jl
+++ b/src/repop.jl
@@ -84,7 +84,19 @@ function (*)(p1::Polyhedron, p2::Polyhedron)
     end
 end
 
-function (*)(rep::RepT, P::AbstractMatrix) where RepT<:HRep
+"""
+    \\(P::AbstractMatrix, p::HRep)
+
+Transform the polyhedron represented by ``p`` into ``P^{-1} p`` by transforming each halfspace ``\\langle a, x \\rangle \\le \\beta`` into ``\\langle P^\\top a, x \\rangle \\le \\beta`` and each hyperplane ``\\langle a, x \\rangle = \\beta`` into ``\\langle P^\\top a, x \\rangle = \\beta``.
+"""
+(\)(P::AbstractMatrix, rep::HRep) = rep / P'
+
+"""
+    /(p::HRep, P::AbstractMatrix)
+
+Transform the polyhedron represented by ``p`` into ``P^{-T} p`` by transforming each halfspace ``\\langle a, x \\rangle \\le \\beta`` into ``\\langle P a, x \\rangle \\le \\beta`` and each hyperplane ``\\langle a, x \\rangle = \\beta`` into ``\\langle P a, x \\rangle = \\beta``.
+"""
+function (/)(rep::RepT, P::AbstractMatrix) where RepT<:HRep
     Nin = fulldim(rep)
     Tin = eltype(rep)
     if size(P, 1) != Nin
@@ -95,7 +107,7 @@ function (*)(rep::RepT, P::AbstractMatrix) where RepT<:HRep
     if RepT <: HRepresentation
         RepTout = lazychangeboth(RepT, Nout, Tout)
     end
-    f = (i, h) -> h * P
+    f = (i, h) -> h / P
     if decomposedhfast(rep)
         eqs = EqIterator{Nout,Tout,Nin,Tin}([rep], f)
         ineqs = IneqIterator{Nout,Tout,Nin,Tin}([rep], f)
@@ -113,6 +125,14 @@ function (*)(rep::RepT, P::AbstractMatrix) where RepT<:HRep
         end
     end
 end
+
+(*)(rep::HRep, P::AbstractMatrix) = warn("`*(p::HRep, P::AbstractMatrix)` is deprecated. Use `P \\ p` or `p / P'` instead.")
+
+"""
+    *(P::AbstractMatrix, p::HRep)
+
+Transform the polyhedron represented by ``p`` into ``P p`` by transforming each element of the V-representation (points, symmetric points, rays and lines) `x` into ``P x``.
+"""
 function (*)(P::AbstractMatrix, rep::RepT) where RepT<:VRep
     Nin = fulldim(rep)
     Tin = eltype(rep)


### PR DESCRIPTION
The set `inv(A) * p` where A is a matrix and p is a polyhedron can be easily obtained by multiplying each H-representation element by the transpose of A.
The syntax was `p * A` but it is a bit inconsistent.
The new syntax is `A \ p` which makes sense since the set is `inv(A) * p`. Doing `inv(A) * p` would instead multiply each V-representation element by the inverse of `A`. The advantage of `A \ p` is that it also works for non-invertible matrix `A`.
In `Base`, `a \ b` is equivalent to `(b' / a')'` so for consistency, `p / A` is equivalent to `A' \ p`.