### PR TITLE
update Simple{H|V}Representation constructors and warnings

### DIFF
--- a/src/matrep.jl
+++ b/src/matrep.jl
@@ -148,10 +148,10 @@ end
 export SimpleHRepresentation, SimpleVRepresentation
 
 function SimpleHRepresentation(args...)
-    warn("`SimpleHRepresentation` is deprecated, it has been renamed to `MixedMatHRep`. It is recommended to use `hrep` to build a `MixedMatHRep`, e.g. `hrep([1 2; 3 4], [5, 6])` for `x + 2y ≤ 5` and `3x + 4y ≤ 6`.")
-    MixedMatHRep(args...)
+    Base.depwarn("`SimpleHRepresentation` is deprecated, it has been renamed to `MixedMatHRep`. It is recommended to use `hrep` to build a `MixedMatHRep`, e.g. `hrep([1 2; 3 4], [5, 6])` for `x + 2y ≤ 5` and `3x + 4y ≤ 6`.", :SimpleHRepresentation)
+    hrep(args...)
 end
 function SimpleVRepresentation(args...)
-    warn("`SimpleVRepresentation` is deprecated, it has been renamed to `MixedMatVRep` It is recommended to use `vrep` to build a `MixedMatVRep`, e.g. `vrep([1 2; 3 4])` for the convex hull of `(1, 2)` and `(3, 4)`.")
-    MixedMatVRep(args...)
+    Base.depwarn("`SimpleVRepresentation` is deprecated, it has been renamed to `MixedMatVRep` It is recommended to use `vrep` to build a `MixedMatVRep`, e.g. `vrep([1 2; 3 4])` for the convex hull of `(1, 2)` and `(3, 4)`.", :SimpleVRepresentation)
+    vrep(args...)
 end

--- a/test/representation.jl
+++ b/test/representation.jl
@@ -102,7 +102,8 @@ Polyhedra.@subrepelem InconsistentVRep Ray rays
                          ((@inferred hrep(hps, hss)), Vector{Float64}),
                          ((@inferred hrep(shps, shss)), SVector{3, Float64}),
                          (hrep([1 2 3; 4 5 6], [7., 8], IntSet([1])), Vector{Float64}),
-                         (SimpleHRepresentation([1 2 3; 4 5 6], [7., 8], IntSet([1])), Vector{Float64}))
+                         (SimpleHRepresentation([1 2 3; 4 5 6], [7., 8], IntSet([1])), Vector{Float64}),
+                         (SimpleHRepresentation([1 2 3; 4 5 6], [7., 8]), Vector{Float64}))
             @test (@inferred coefficienttype(hr)) == Float64
             @test                                               (@inferred eltype(allhalfspaces(hr)))  == HalfSpace{3, Float64, AT}
             @test                                               (@inferred collect(allhalfspaces(hr))) isa Vector{HalfSpace{3, Float64, AT}}
@@ -145,7 +146,9 @@ Polyhedra.@subrepelem InconsistentVRep Ray rays
                          ((@inferred vrep(ps, ls, rs)), Vector{Int}),
                          ((@inferred vrep(sps, sls, srs)), SVector{2, Int}),
                          (vrep([1 2; 3 4]), Vector{Int}),
-                         (SimpleVRepresentation([1 2; 3 4], zeros(Int, 0, 0), IntSet()), Vector{Int}))
+                         (SimpleVRepresentation([1 2; 3 4], zeros(Int, 0, 0), IntSet()), Vector{Int}),
+                         (SimpleVRepresentation([1 2; 3 4], zeros(Int, 0, 0)), Vector{Int}),
+                         (SimpleVRepresentation([1 2; 3 4]), Vector{Int}))
             @test (@inferred coefficienttype(vr)) == Int
 #            @test (@inferred Polyhedra.sympointtype(vr)) == (@inferred eltype(sympoints(vr)))  == SymPoint{2, Int, AT}
 #            @test                                           (@inferred collect(sympoints(vr))) isa Vector{SymPoint{2, Int, AT}}


### PR DESCRIPTION
Call the (suggested) `hrep` and `vrep` instead of trying to forward to `MixedMat{H|V}Rep`

I also changed the plain `warn` to a `Base.depwarn` which will only print once if the function is called in a loop to avoid spamming the user, and which is also configurable with the global `--depwarn` command-line flag. 

Fixes #90 