### PR TITLE
Fix 0.7 errors for using Polyhedra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ os:
   - osx
 julia:
   - 0.6
+  - 0.7
+matrix:
+  allow_failures:
+    - julia: 0.7
 #addons:
 #  apt_packages:
 #    - libgmp-dev # For CDDLib and LRSLib

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ MultivariatePolynomials 0.1.1
 MathProgBase 0.5.10 0.8
 JuMP 0.16
 RecipesBase 0.2
+Nullables

--- a/src/Polyhedra.jl
+++ b/src/Polyhedra.jl
@@ -17,6 +17,8 @@ using StaticArrays.FixedSizeArrays: FixedVector
 using MathProgBase
 const MPB = MathProgBase
 
+using Nullables
+
 # Similar to StaticArrays.Size
 struct FullDim{N}
     function FullDim{N}() where N


### PR DESCRIPTION
Enables `using Polyhedra` in v0.7 (with some tests failing though).