### PR TITLE
Update 3D plotting

### DIFF
--- a/examples/3D Plotting a projection of the 4D permutahedron.ipynb
+++ b/examples/3D Plotting a projection of the 4D permutahedron.ipynb
@@ -1,0 +1,250 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this notebook we plot the [permutahedron](https://en.wikipedia.org/wiki/Permutohedron) of order 4 which is a 3-dimensional polyhedron living in a 4-dimensional space.\n",
+    "It is defined as the convex hull of all permutations of $(0, 1, 2, 3)$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "V-representation Polyhedra.PointsHull{Int64,Array{Int64,1},Int64}:\n",
+       "24-element iterator of Array{Int64,1}:\n",
+       " [0, 1, 2, 3]\n",
+       " [0, 1, 3, 2]\n",
+       " [0, 2, 1, 3]\n",
+       " [0, 2, 3, 1]\n",
+       " [0, 3, 1, 2]\n",
+       " [0, 3, 2, 1]\n",
+       " [1, 0, 2, 3]\n",
+       " [1, 0, 3, 2]\n",
+       " [1, 2, 0, 3]\n",
+       " [1, 2, 3, 0]\n",
+       " [1, 3, 0, 2]\n",
+       " [1, 3, 2, 0]\n",
+       " [2, 0, 1, 3]\n",
+       " [2, 0, 3, 1]\n",
+       " [2, 1, 0, 3]\n",
+       " [2, 1, 3, 0]\n",
+       " [2, 3, 0, 1]\n",
+       " [2, 3, 1, 0]\n",
+       " [3, 0, 1, 2]\n",
+       " [3, 0, 2, 1]\n",
+       " [3, 1, 0, 2]\n",
+       " [3, 1, 2, 0]\n",
+       " [3, 2, 0, 1]\n",
+       " [3, 2, 1, 0]"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "using Combinatorics, Polyhedra\n",
+    "v = vrep(collect(permutations([0, 1, 2, 3])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To plot a polyhedron, we need both the H-representation and V-representation so we will need a library to do representation conversion.\n",
+    "We choose [CDD](https://github.com/JuliaPolyhedra/CDDLib.jl) in floating point arithmetic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Polyhedron CDDLib.Polyhedron{Float64}:\n",
+       "24-element iterator of Array{Float64,1}:\n",
+       " [0.0, 1.0, 2.0, 3.0]\n",
+       " [0.0, 1.0, 3.0, 2.0]\n",
+       " [0.0, 2.0, 1.0, 3.0]\n",
+       " [0.0, 2.0, 3.0, 1.0]\n",
+       " [0.0, 3.0, 1.0, 2.0]\n",
+       " [0.0, 3.0, 2.0, 1.0]\n",
+       " [1.0, 0.0, 2.0, 3.0]\n",
+       " [1.0, 0.0, 3.0, 2.0]\n",
+       " [1.0, 2.0, 0.0, 3.0]\n",
+       " [1.0, 2.0, 3.0, 0.0]\n",
+       " [1.0, 3.0, 0.0, 2.0]\n",
+       " [1.0, 3.0, 2.0, 0.0]\n",
+       " [2.0, 0.0, 1.0, 3.0]\n",
+       " [2.0, 0.0, 3.0, 1.0]\n",
+       " [2.0, 1.0, 0.0, 3.0]\n",
+       " [2.0, 1.0, 3.0, 0.0]\n",
+       " [2.0, 3.0, 0.0, 1.0]\n",
+       " [2.0, 3.0, 1.0, 0.0]\n",
+       " [3.0, 0.0, 1.0, 2.0]\n",
+       " [3.0, 0.0, 2.0, 1.0]\n",
+       " [3.0, 1.0, 0.0, 2.0]\n",
+       " [3.0, 1.0, 2.0, 0.0]\n",
+       " [3.0, 2.0, 0.0, 1.0]\n",
+       " [3.0, 2.0, 1.0, 0.0]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "using CDDLib\n",
+    "p4 = polyhedron(v, CDDLib.Library())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The permutahedron lives in a 4-dimension space but is 3-dimensional as it is contained in the hyperplane $x_1 + x_2 + x_3 + x_4 = 0 + 1 + 2 + 3 = 6$.\n",
+    "We choose an orthogonal basis of this hyperplane: $(1, -1, 0, 0)$, $(1, 1, -2, 0)$ and $(1, 1, 1, -3)$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v1 = [1, -1,  0,  0]\n",
+    "v2 = [1,  1, -2,  0]\n",
+    "v3 = [1,  1,  1, -3];"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We project the polyhedron in this basis to obtain a full dimensional 3-dimensional polyhedron living in a 3-dimensional space."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Polyhedron CDDLib.Polyhedron{Float64}:\n",
+       "14-element iterator of HalfSpace{Float64,Array{Float64,1}}:\n",
+       " HalfSpace([-0.0, 3.26599, -1.1547], 6.0)\n",
+       " HalfSpace([1.41421, 0.816497, -1.1547], 3.9999999999999996)\n",
+       " HalfSpace([-0.0, -0.0, -1.1547], 2.0)\n",
+       " HalfSpace([-1.41421, 0.816497, -1.1547], 3.999999999999999)\n",
+       " HalfSpace([-2.82843, -1.63299, -1.1547], 6.0)\n",
+       " HalfSpace([-0.0, -1.63299, -1.1547], 4.000000000000001)\n",
+       " HalfSpace([-1.41421, -0.816497, 1.1547], 4.000000000000002)\n",
+       " HalfSpace([-0.0, -3.26599, 1.1547], 6.000000000000011)\n",
+       " HalfSpace([-2.82843, 1.63299, 1.1547], 5.999999999999995)\n",
+       " HalfSpace([2.82843, -1.63299, -1.1547], 6.0)\n",
+       " HalfSpace([1.41421, -0.816497, 1.1547], 4.0000000000000036)\n",
+       " HalfSpace([-0.0, -0.0, 1.1547], 2.0)\n",
+       " HalfSpace([-0.0, 1.63299, 1.1547], 3.9999999999999964)\n",
+       " HalfSpace([2.82843, 1.63299, 1.1547], 5.9999999999999964)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p3 = project(p4, [v1 v2 v3])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To get a plottable object, we transform the polyhedron into a mesh as follows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = Polyhedra.Mesh(p3);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now plot this mesh with [MeshCat](https://github.com/rdeits/MeshCat.jl) or [Makie](https://github.com/JuliaPlots/Makie.jl) as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using MeshCat\n",
+    "vis = Visualizer()\n",
+    "setobject!(vis, m)\n",
+    "IJuliaCell(vis)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using Makie\n",
+    "mesh(m, color=:blue)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using Makie\n",
+    "wireframe(m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.0.1",
+   "language": "julia",
+   "name": "julia-1.0"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.0.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/decompose.jl
+++ b/src/decompose.jl
@@ -1,21 +1,21 @@
 import GeometryTypes
 
-struct PolyhedronGeometry{N, T, PT <: Polyhedron{T}} <: GeometryTypes.GeometryPrimitive{N, T}
+struct Geometry{N, T, PT <: Polyhedron{T}} <: GeometryTypes.GeometryPrimitive{N, T}
     polyhedron::PT
 end
-function PolyhedronGeometry{N}(polyhedron::Polyhedron{T}) where {N, T}
-    return PolyhedronGeometry{N, T, typeof(polyhedron)}(polyhedron)
+function Geometry{N}(polyhedron::Polyhedron{T}) where {N, T}
+    return Geometry{N, T, typeof(polyhedron)}(polyhedron)
 end
-function PolyhedronGeometry(polyhedron::Polyhedron, ::StaticArrays.Size{N}) where N
-    return PolyhedronGeometry{N[1]}(polyhedron)
+function Geometry(polyhedron::Polyhedron, ::StaticArrays.Size{N}) where N
+    return Geometry{N[1]}(polyhedron)
 end
-function PolyhedronGeometry(polyhedron::Polyhedron, N::Int)
+function Geometry(polyhedron::Polyhedron, N::Int)
     # This is type unstable but there is no way around that,
     # use polyhedron built from StaticArrays vector to avoid that.
-    return PolyhedronGeometry{N}(polyhedron)
+    return Geometry{N}(polyhedron)
 end
-function PolyhedronGeometry(polyhedron::Polyhedron)
-    return PolyhedronGeometry(polyhedron, FullDim(polyhedron))
+function Geometry(polyhedron::Polyhedron)
+    return Geometry(polyhedron, FullDim(polyhedron))
 end
 
 # Creates a scene for the vizualisation to be used to truncate the lines and rays
@@ -53,10 +53,8 @@ function _isdup(zray, triangles)
 end
 _isdup(poly, hidx, triangles) = _isdup(get(poly, hidx).a, triangles)
 
-function fulldecompose(poly::Polyhedron, ::Type{T}) where T
-    if fulldim(poly) != 3
-        error("Only 3-dimensional polyhedra are supported")
-    end
+function fulldecompose(poly_geom::Geometry{3}, ::Type{T}) where T
+    poly = poly_geom.polyhedron
     exit_point = scene(poly, T)
 
     triangles = Tuple{Tuple{Vector{T},Vector{T},Vector{T}}, Vector{T}}[]
@@ -219,20 +217,20 @@ function fulldecompose(poly::Polyhedron, ::Type{T}) where T
     (pts, faces, ns)
 end
 
-fulldecompose(poly::Polyhedron{T}) where T = fulldecompose(poly, typeof(one(T)/2))
+fulldecompose(poly::Geometry{N, T}) where {N, T} = fulldecompose(poly, typeof(one(T)/2))
 
-GeometryTypes.isdecomposable(::Type{T}, ::Type{S}) where {T<:GeometryTypes.Point, S<:Polyhedron} = true
-GeometryTypes.isdecomposable(::Type{T}, ::Type{S}) where {T<:GeometryTypes.Face, S<:Polyhedron} = true
-GeometryTypes.isdecomposable(::Type{T}, ::Type{S}) where {T<:GeometryTypes.Normal, S<:Polyhedron} = true
-function GeometryTypes.decompose(PT::Type{<:GeometryTypes.Point}, poly::Polyhedron)
+GeometryTypes.isdecomposable(::Type{<:GeometryTypes.Point{3}},  ::Type{<:Geometry{3}}) = true
+GeometryTypes.isdecomposable(::Type{<:GeometryTypes.Face{3}},   ::Type{<:Geometry{3}}) = true
+GeometryTypes.isdecomposable(::Type{<:GeometryTypes.Normal{3}}, ::Type{<:Geometry{3}}) = true
+function GeometryTypes.decompose(PT::Type{<:GeometryTypes.Point}, poly::Geometry)
     points = fulldecompose(poly)[1]
     map(PT, points)
 end
-function GeometryTypes.decompose(FT::Type{<:GeometryTypes.Face}, poly::Polyhedron)
+function GeometryTypes.decompose(FT::Type{<:GeometryTypes.Face}, poly::Geometry)
     faces = fulldecompose(poly)[2]
     GeometryTypes.decompose(FT, faces)
 end
-function GeometryTypes.decompose(NT::Type{<:GeometryTypes.Normal}, poly::Polyhedron)
+function GeometryTypes.decompose(NT::Type{<:GeometryTypes.Normal}, poly::Geometry)
     ns = fulldecompose(poly)[3]
     map(NT, ns)
 end

--- a/test/decompose.jl
+++ b/test/decompose.jl
@@ -20,7 +20,7 @@ end
 
 nfaces(d::Dict{<:Any, Face}) = length(d)
 nfaces(d::Dict{<:Any, <:Vector}) = sum(map(length, values(d)))
-function test_decompose(p::Polyhedra.Geometry, d::Dict)
+function test_decompose(p::Polyhedra.Mesh, d::Dict)
     @test GeometryTypes.isdecomposable(GeometryTypes.Point{3, Float32}, typeof(p))
     points = GeometryTypes.decompose(GeometryTypes.Point{3, Float32}, p)
     @test GeometryTypes.isdecomposable(GeometryTypes.Face{3, Int}, typeof(p))
@@ -54,7 +54,7 @@ function test_decompose(p::Polyhedra.Geometry, d::Dict)
     end
     @test isempty(d)
 end
-test_decompose(p::Polyhedron, d::Dict) = test_decompose(Polyhedra.Geometry(p), d)
+test_decompose(p::Polyhedron, d::Dict) = test_decompose(Polyhedra.Mesh(p), d)
 
 function orthantdecomposetest(lib::Polyhedra.Library)
     v = vrep([Ray([1., 0, 0]),

--- a/test/decompose.jl
+++ b/test/decompose.jl
@@ -20,7 +20,7 @@ end
 
 nfaces(d::Dict{<:Any, Face}) = length(d)
 nfaces(d::Dict{<:Any, <:Vector}) = sum(map(length, values(d)))
-function test_decompose(p::Polyhedron, d::Dict)
+function test_decompose(p::Polyhedra.Geometry, d::Dict)
     @test GeometryTypes.isdecomposable(GeometryTypes.Point{3, Float32}, typeof(p))
     points = GeometryTypes.decompose(GeometryTypes.Point{3, Float32}, p)
     @test GeometryTypes.isdecomposable(GeometryTypes.Face{3, Int}, typeof(p))
@@ -54,6 +54,7 @@ function test_decompose(p::Polyhedron, d::Dict)
     end
     @test isempty(d)
 end
+test_decompose(p::Polyhedron, d::Dict) = test_decompose(Polyhedra.Geometry(p), d)
 
 function orthantdecomposetest(lib::Polyhedra.Library)
     v = vrep([Ray([1., 0, 0]),


### PR DESCRIPTION
@rdeits @SimonDanisch I have added a example notebook to show how to plot polyhedra using either Makie or MeshCat. Note that the user now need to wrap the polyhedron in a Mesh while you could just plot it directly. This is because Polyhedron is no longer a subtype of `GeometryType.GeometryPrimitive{N, T}` since the dimension is not part of the argument type anymore (see https://github.com/JuliaPolyhedra/Polyhedra.jl/pull/116).
In short, if `p` is a `Polyhedron`, `p` cannot be plotted but `Polyhedra.Mesh(p)` is a `GeometryType.GeometryPrimitive{N, T}` which can be plotted.

Closes https://github.com/JuliaPolyhedra/Polyhedra.jl/issues/117