### PR TITLE
Ensure shape is closed

### DIFF
--- a/src/recipe.jl
+++ b/src/recipe.jl
@@ -50,6 +50,7 @@ end
         pop!(bot)
     end
     hull = [top; bot]
+    push!(hull, hull[1])  # ensure shape is closed
     seriestype --> :shape
     legend --> false
     [p[1] for p in hull], [p[2] for p in hull]

--- a/test/recipe.jl
+++ b/test/recipe.jl
@@ -2,8 +2,8 @@ import RecipesBase
 function recipetest(lib::Polyhedra.Library)
     v = convexhull([0.0, 0.0], [1.0, 0.0], [0.0, 1.0])
     p = polyhedron(v)
-    @test RecipesBase.apply_recipe(Dict{Symbol, Any}(), p)[1].args == ([0.0, 0.0, 1.0],
-                                                                       [0.0, 1.0, 0.0])
+    @test RecipesBase.apply_recipe(Dict{Symbol, Any}(), p)[1].args == ([0.0, 0.0, 1.0, 0.0],
+                                                                       [0.0, 1.0, 0.0, 0.0])
     @testset "Error for unbounded polyhedron" begin
         vr = convexhull(v, Ray([1.0, 1.0]))
         pr = polyhedron(vr)


### PR DESCRIPTION
I suppose sometime recently, `Plots` may have changed its interpretation of the `seriestype=:shape`. Before this commit, a closed (bounded) polygon had an edge missing.

I'm not sure when Plots changed, but I know it was between `Plots 0.17.4` and `Plots v0.21.0`.

