### PR TITLE
[WIP] Update polyhedron(::JuMP.Model) to Jump 0.19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+.#*
+.*.swp

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.7
 StaticArrays 0.5
 MathProgBase 0.5.10 0.8
-JuMP 0.16 0.19
+JuMP 0.19
 GeometryTypes 0.4
 RecipesBase 0.2

--- a/src/jump.jl
+++ b/src/jump.jl
@@ -41,12 +41,14 @@ function _prepVariableBounds(m::Model)
     l = fill(-Inf, nvar)
     # Variable upper bounds
     u = fill(+Inf, nvar)
-    @inbounds for ind in 1:nvar
-        set = var_bounds[ind].set
+    @inbounds for bound_ind in 1:length(var_bounds)
+        constr = var_bounds[bound_ind]
+        var_ind = constr.func.index.value
+        set = constr.set
         if set isa MOI.GreaterThan
-            l[ind] = set.lower
+            l[var_ind] = set.lower
         elseif set isa MOI.LessThan
-            u[ind] = set.upper
+            u[var_ind] = set.upper
         end
     end
 

--- a/src/jump.jl
+++ b/src/jump.jl
@@ -25,14 +25,18 @@ end
 function prepConstrBounds(m::Model)
 
     # Create dense affine constraint bound vectors
-    linconstr = m.linconstr::Vector{LinearConstraint}
+    linconstr = _get_constraint_array(m)
     numRows = length(linconstr)
     # -Inf means no lower bound, +Inf means no upper bound
     rowlb = fill(-Inf, numRows)
     rowub = fill(+Inf, numRows)
     @inbounds for ind in 1:numRows
-        rowlb[ind] = linconstr[ind].lb
-        rowub[ind] = linconstr[ind].ub
+        set = linconstr[ind].set
+        if set isa MOI.GreaterThan
+            rowlb[ind] = set.lower
+        elseif set isa MOI.LessThan
+            rowlb[ind] = set.upper
+        end
     end
 
     return rowlb, rowub

--- a/src/jump.jl
+++ b/src/jump.jl
@@ -21,15 +21,23 @@ function _get_all_constraint_array(model::Model)
     )
 end
 
+function _filter_var_bounds(constr)
+    constr isa VariableRef | constr isa VectorofVariables
+end
+
+function _filter_aff_constr(constr)
+    constr isa GenericAffExpr | constr isa VectorAffineFunction
+end
+
 function _get_var_bounds_array(model::Model)
     constraint_arr = _get_all_constraint_array(model)
-    var_bounds = filter(c -> c.func isa VariableRef, constraint_arr)
+    var_bounds = filter(_filter_var_bounds, constraint_arr)
     return var_bounds
 end
 
 function _get_aff_constr_array(model::Model)
     constraint_arr = _get_all_constraint_array(model)
-    linconstr = filter(c -> c.func isa GenericAffExpr, constraint_arr)
+    linconstr = filter(_filter_aff_constr, constraint_arr)
     return linconstr
 end
 

--- a/src/jump.jl
+++ b/src/jump.jl
@@ -9,10 +9,10 @@ Note that if non-linear constraint are present in the model, they are ignored.
 hrep(model::JuMP.Model) = LPHRepresentation(model)
 
 function _get_all_constraint_ref_array(model::Model)
-    ref_arr = vcat([
+    ref_arr = reduce(vcat, [
         all_constraints(model, c...)
         for c in list_of_constraint_types(model)
-    ]...)
+    ])
 end
 
 function _get_all_constraint_array(model::Model)
@@ -108,7 +108,7 @@ function prepConstrMatrix(m::Model)
     nnz = 0
     for c in 1:numRows
         func = linconstr[c].func
-        vars, coeffs = zip(linconstr[c].func.terms...)
+        vars, coeffs = map(f -> collect(f(linconstr[c].func.terms)), (keys, values))
         @assert all(isfinite.(coeffs))
         # Record all (i,j,v) triplets
         @inbounds for ind in 1:length(coeffs)

--- a/src/jump.jl
+++ b/src/jump.jl
@@ -8,11 +8,72 @@ Note that if non-linear constraint are present in the model, they are ignored.
 """
 hrep(model::JuMP.Model) = LPHRepresentation(model)
 
+# Returns affine constraint lower and upper bounds, all as dense vectors
+function prepConstrBounds(m::Model)
+
+    # Create dense affine constraint bound vectors
+    linconstr = m.linconstr::Vector{LinearConstraint}
+    numRows = length(linconstr)
+    # -Inf means no lower bound, +Inf means no upper bound
+    rowlb = fill(-Inf, numRows)
+    rowub = fill(+Inf, numRows)
+    @inbounds for ind in 1:numRows
+        rowlb[ind] = linconstr[ind].lb
+        rowub[ind] = linconstr[ind].ub
+    end
+
+    return rowlb, rowub
+end
+
+# Converts all the affine constraints into a sparse column-wise
+# matrix of coefficients.
+function prepConstrMatrix(m::Model)
+
+    linconstr = m.linconstr::Vector{LinearConstraint}
+    numRows = length(linconstr)
+    # Calculate the maximum number of nonzeros
+    # The actual number may be less because of cancelling or
+    # zero-coefficient terms
+    nnz = 0
+    for c in 1:numRows
+        nnz += length(linconstr[c].terms.coeffs)
+    end
+    # Non-zero row indices
+    I = Array{Int}(nnz)
+    # Non-zero column indices
+    J = Array{Int}(nnz)
+    # Non-zero values
+    V = Array{Float64}(nnz)
+
+    # Fill it up!
+    # Number of nonzeros seen so far
+    nnz = 0
+    for c in 1:numRows
+        # Check that no coefficients are NaN/Inf
+        assert_isfinite(linconstr[c].terms)
+        coeffs = linconstr[c].terms.coeffs
+        vars   = linconstr[c].terms.vars
+        # Check that variables belong to this model
+        if !verify_ownership(m, vars)
+            throw(VariableNotOwnedError("constraint"))
+        end
+        # Record all (i,j,v) triplets
+        @inbounds for ind in 1:length(coeffs)
+            nnz += 1
+            I[nnz] = c
+            J[nnz] = vars[ind].col
+            V[nnz] = coeffs[ind]
+        end
+    end
+
+    # sparse() handles merging duplicate terms and removing zeros
+    A = sparse(I,J,V,numRows,m.numCols)
+end
+
 function LPHRepresentation(model::JuMP.Model)
     # Inspired from Joey Huchette's code in ConvexHull.jl
-    A = JuMP.prepConstrMatrix(model)
-    c = JuMP.prepAffObjective(model)
-    lb, ub = JuMP.prepConstrBounds(model)
+    A = prepConstrMatrix(model)
+    lb, ub = prepConstrBounds(model)
     l, u = model.colLower, model.colUpper
 
     m, n = size(A)

--- a/src/jump.jl
+++ b/src/jump.jl
@@ -71,7 +71,7 @@ function prepConstrBounds(m::Model)
         if set isa MOI.GreaterThan
             rowlb[ind] = set.lower
         elseif set isa MOI.LessThan
-            rowlb[ind] = set.upper
+            rowub[ind] = set.upper
         end
     end
 


### PR DESCRIPTION
Hi all,

Thanks for the great package! I've been working on updating the LP -> polyhedron conversion method to JuMP 0.19 (solves #152 in part). It seems to be working for the simple case I've dealt with, though I haven't yet written proper tests so far.

I'm additionally having a bit of a versioning issue, #154, which is preventing me from running tests properly.

Any feedback and suggestions are appreciated!

Cheers,
Oliver