### PR TITLE
Add support_function and scalar * poly

### DIFF
--- a/docs/src/redundancy.md
+++ b/docs/src/redundancy.md
@@ -6,6 +6,7 @@ in
 issubset
 ininterior
 inrelativeinterior
+support_function
 ```
 
 ## Linearity

--- a/examples/Minimal Robust Positively Invariant Set.ipynb
+++ b/examples/Minimal Robust Positively Invariant Set.ipynb
@@ -65,7 +65,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The set of disturbance the unit ball of the infinity norm."
+    "The set of disturbance is the unit ball of the infinity norm."
    ]
   },
   {

--- a/examples/Minimal Robust Positively Invariant Set.ipynb
+++ b/examples/Minimal Robust Positively Invariant Set.ipynb
@@ -1,0 +1,747 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this example, we implement the method presented in [RKKM05] to compute a robust positively invariant polytope of a linear system under a disturbance bounded by a polytopic set.\n",
+    "\n",
+    "We consider the example given in equation (15) of [RKKM05]:\n",
+    "$$x^+ =\n",
+    "\\begin{bmatrix}\n",
+    "  1 & 1\\\\\n",
+    "  0 & 1\n",
+    "\\end{bmatrix}x +\n",
+    "\\begin{bmatrix}\n",
+    "  1\\\\\n",
+    "  1\n",
+    "\\end{bmatrix} u\n",
+    "+ w$$\n",
+    "with the state feedback control $u(x) = -\\begin{bmatrix}1.17 & 1.03\\end{bmatrix} x$.\n",
+    "The controlled system is therefore\n",
+    "$$x^+ =\n",
+    "\\left(\\begin{bmatrix}\n",
+    "  1 & 1\\\\\n",
+    "  0 & 1\n",
+    "\\end{bmatrix} -\n",
+    "\\begin{bmatrix}\n",
+    "  1\\\\\n",
+    "  1\n",
+    "\\end{bmatrix}\n",
+    "\\begin{bmatrix}1.17 & 1.03\\end{bmatrix}\\right)x\n",
+    "+ w =\n",
+    "\\begin{bmatrix}\n",
+    "  -0.17 & -0.03\\\\\n",
+    "  -1.17 & -0.03\n",
+    "\\end{bmatrix}x\n",
+    "+ w.$$\n",
+    "\n",
+    "[RKKM05] Sasa V. Rakovic, Eric C. Kerrigan, Konstantinos I. Kouramas, David Q. Mayne *Invariant approximations of the minimal robust positively Invariant set*. IEEE Transactions on Automatic Control 50 (**2005**): 406-410."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2×2 Array{Float64,2}:\n",
+       " -0.17  -0.03\n",
+       " -1.17  -0.03"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "A = [1 1; 0 1] - [1; 1] * [1.17 1.03]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The set of disturbance the unit ball of the infinity norm."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "V-representation Polyhedra.PointsHull{Float64,Array{Float64,1},Int64}:\n",
+       "4-element iterator of Array{Float64,1}:\n",
+       " [-1.0, -1.0]\n",
+       " [-1.0, 1.0]\n",
+       " [1.0, -1.0]\n",
+       " [1.0, 1.0]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "using Polyhedra\n",
+    "Wv = vrep([[x, y] for x in [-1.0, 1.0] for y in [-1.0, 1.0]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will use the [CDDLib](https://github.com/JuliaPolyhedra/CDDLib.jl) for this example but feel free to use any other library from [this list of available libraries](https://juliapolyhedra.github.io/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Polyhedron CDDLib.Polyhedron{Float64}:\n",
+       "4-element iterator of Array{Float64,1}:\n",
+       " [-1.0, -1.0]\n",
+       " [-1.0, 1.0]\n",
+       " [1.0, -1.0]\n",
+       " [1.0, 1.0]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "using CDDLib\n",
+    "W = polyhedron(Wv, CDDLib.Library())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The $F_s$ function of equation (2) of [RKKM05] can be implemented as follows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Fs (generic function with 2 methods)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function Fs(s::Integer, verbose=1)\n",
+    "    @assert s ≥ 1\n",
+    "    F = W\n",
+    "    A_W = W\n",
+    "    for i in 1:(s-1)\n",
+    "        A_W = A * A_W\n",
+    "        F += A_W\n",
+    "        if verbose ≥ 1\n",
+    "            println(\"Number of points after adding A^$i * W: \", npoints(F))\n",
+    "        end\n",
+    "        removevredundancy!(F)\n",
+    "        if verbose ≥ 1\n",
+    "            println(\"Number of points after removing redundant ones: \", npoints(F))\n",
+    "        end\n",
+    "    end\n",
+    "    return F\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see below that only the V-representation is computed. In fact, no H-representation was ever computed during `Fs`. Computing $AW$ is done by multiplying all the points by $A$ and doing the Minkowski sum is done by summing each pair of points. The redundancy removal is carried out by CDD, internal LP solver."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of points after adding A^1 * W: 16\n",
+      "Number of points after removing redundant ones: 8\n",
+      "Number of points after adding A^2 * W: 32\n",
+      "Number of points after removing redundant ones: 12\n",
+      "Number of points after adding A^3 * W: 48\n",
+      "Number of points after removing redundant ones: 16\n",
+      "Number of points after adding A^4 * W: 64\n",
+      "Number of points after removing redundant ones: 20\n",
+      "Number of points after adding A^5 * W: 80\n",
+      "Number of points after removing redundant ones: 24\n",
+      "Number of points after adding A^6 * W: 96\n",
+      "Number of points after removing redundant ones: 28\n",
+      "Number of points after adding A^7 * W: 112\n",
+      "Number of points after removing redundant ones: 31\n",
+      "Number of points after adding A^8 * W: 124\n",
+      "Number of points after removing redundant ones: 33\n",
+      "Number of points after adding A^9 * W: 132\n",
+      "Number of points after removing redundant ones: 31\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Polyhedron CDDLib.Polyhedron{Float64}:\n",
+       "31-element iterator of Array{Float64,1}:\n",
+       " [-1.29869, -2.59738]\n",
+       " [-0.701305, 2.59738]\n",
+       " [-0.958695, 1.74262]\n",
+       " [-0.889305, 2.06938]\n",
+       " [-0.910895, 1.97842]\n",
+       " [-0.904505, 2.00638]\n",
+       " [-0.906421, 1.9981]\n",
+       " [-0.905944, 2.00017]\n",
+       " [-0.906312, 1.99857]\n",
+       " [-0.904871, 2.00481]\n",
+       " [-0.909695, 1.98382]\n",
+       " [-0.893505, 2.05318]\n",
+       " [-0.946695, 1.81462]\n",
+       " [-0.761305, 2.53738]\n",
+       " [-1.29869, -0.597375]\n",
+       " [1.29869, 0.597375]\n",
+       " [0.761305, -2.53738]\n",
+       " [0.946695, -1.81462]\n",
+       " [0.893505, -2.05318]\n",
+       " [0.909695, -1.98382]\n",
+       " [0.904871, -2.00481]\n",
+       " [0.906312, -1.99857]\n",
+       " [0.905889, -2.00041]\n",
+       " [0.905856, -2.00055]\n",
+       " [0.906421, -1.9981]\n",
+       " [0.904505, -2.00638]\n",
+       "  ⋮"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Fs(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Figure 1 of [RKKM05] can be reproduced as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n",
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"600\" height=\"400\" viewBox=\"0 0 2400 1600\">\n",
+       "<defs>\n",
+       "  <clipPath id=\"clip0100\">\n",
+       "    <rect x=\"0\" y=\"0\" width=\"2400\" height=\"1600\"/>\n",
+       "  </clipPath>\n",
+       "</defs>\n",
+       "<polygon clip-path=\"url(#clip0100)\" points=\"\n",
+       "0,1600 2400,1600 2400,0 0,0 \n",
+       "  \" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<defs>\n",
+       "  <clipPath id=\"clip0101\">\n",
+       "    <rect x=\"480\" y=\"0\" width=\"1681\" height=\"1600\"/>\n",
+       "  </clipPath>\n",
+       "</defs>\n",
+       "<polygon clip-path=\"url(#clip0100)\" points=\"\n",
+       "149.361,1503.47 2321.26,1503.47 2321.26,47.2441 149.361,47.2441 \n",
+       "  \" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<defs>\n",
+       "  <clipPath id=\"clip0102\">\n",
+       "    <rect x=\"149\" y=\"47\" width=\"2173\" height=\"1457\"/>\n",
+       "  </clipPath>\n",
+       "</defs>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  446.456,1503.47 446.456,47.2441 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  840.883,1503.47 840.883,47.2441 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  1235.31,1503.47 1235.31,47.2441 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  1629.74,1503.47 1629.74,47.2441 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  2024.16,1503.47 2024.16,47.2441 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  149.361,1304.28 2321.26,1304.28 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  149.361,1039.82 2321.26,1039.82 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  149.361,775.359 2321.26,775.359 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  149.361,510.9 2321.26,510.9 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  149.361,246.44 2321.26,246.44 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0100)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  149.361,1503.47 2321.26,1503.47 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0100)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  149.361,1503.47 149.361,47.2441 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0100)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  446.456,1503.47 446.456,1481.63 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0100)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  840.883,1503.47 840.883,1481.63 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0100)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  1235.31,1503.47 1235.31,1481.63 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0100)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  1629.74,1503.47 1629.74,1481.63 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0100)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  2024.16,1503.47 2024.16,1481.63 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0100)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  149.361,1304.28 181.939,1304.28 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0100)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  149.361,1039.82 181.939,1039.82 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0100)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  149.361,775.359 181.939,775.359 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0100)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  149.361,510.9 181.939,510.9 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0100)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  149.361,246.44 181.939,246.44 \n",
+       "  \"/>\n",
+       "<g clip-path=\"url(#clip0100)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 446.456, 1557.47)\" x=\"446.456\" y=\"1557.47\">-1.0</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0100)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 840.883, 1557.47)\" x=\"840.883\" y=\"1557.47\">-0.5</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0100)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 1235.31, 1557.47)\" x=\"1235.31\" y=\"1557.47\">0.0</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0100)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 1629.74, 1557.47)\" x=\"1629.74\" y=\"1557.47\">0.5</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0100)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 2024.16, 1557.47)\" x=\"2024.16\" y=\"1557.47\">1.0</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0100)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 125.361, 1321.78)\" x=\"125.361\" y=\"1321.78\">-2</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0100)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 125.361, 1057.32)\" x=\"125.361\" y=\"1057.32\">-1</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0100)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 125.361, 792.859)\" x=\"125.361\" y=\"792.859\">0</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0100)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 125.361, 528.4)\" x=\"125.361\" y=\"528.4\">1</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0100)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 125.361, 263.94)\" x=\"125.361\" y=\"263.94\">2</text>\n",
+       "</g>\n",
+       "<polygon clip-path=\"url(#clip0102)\" points=\"\n",
+       "210.829,1462.26 210.829,933.341 479.04,314.505 488.506,295.464 516.747,252.146 517.694,250.718 520.276,246.943 520.363,246.817 520.652,246.396 521.499,245.168 \n",
+       "  521.788,244.754 530.465,232.377 533.778,228.093 634.752,104.326 682.083,88.4582 2259.79,88.4582 2259.79,617.378 1991.58,1236.21 1982.11,1255.25 1953.87,1298.57 \n",
+       "  1952.93,1300 1950.34,1303.78 1950.26,1303.9 1949.92,1304.39 1949.9,1304.42 1949.12,1305.55 1948.83,1305.96 1940.16,1318.34 1936.84,1322.63 1835.87,1446.39 \n",
+       "  1788.54,1462.26 210.829,1462.26 210.829,1462.26 \n",
+       "  \" fill=\"#009af9\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  210.829,1462.26 210.829,933.341 479.04,314.505 488.506,295.464 516.747,252.146 517.694,250.718 520.276,246.943 520.363,246.817 520.652,246.396 521.499,245.168 \n",
+       "  521.788,244.754 530.465,232.377 533.778,228.093 634.752,104.326 682.083,88.4582 2259.79,88.4582 2259.79,617.378 1991.58,1236.21 1982.11,1255.25 1953.87,1298.57 \n",
+       "  1952.93,1300 1950.34,1303.78 1950.26,1303.9 1949.92,1304.39 1949.9,1304.42 1949.12,1305.55 1948.83,1305.96 1940.16,1318.34 1936.84,1322.63 1835.87,1446.39 \n",
+       "  1788.54,1462.26 210.829,1462.26 \n",
+       "  \"/>\n",
+       "<polygon clip-path=\"url(#clip0102)\" points=\"\n",
+       "210.841,1462.24 210.841,933.324 479.051,314.488 488.518,295.447 516.759,252.129 517.705,250.701 520.288,246.926 520.374,246.8 520.641,246.413 521.487,245.185 \n",
+       "  521.776,244.771 530.454,232.394 533.767,228.11 634.74,104.343 682.071,88.4751 2259.78,88.4751 2259.78,617.395 1991.57,1236.23 1982.1,1255.27 1953.86,1298.59 \n",
+       "  1952.92,1300.02 1950.33,1303.79 1950.25,1303.92 1950.01,1304.26 1950.01,1304.27 1949.94,1304.37 1949.91,1304.41 1949.13,1305.53 1948.84,1305.95 1940.17,1318.32 \n",
+       "  1936.85,1322.61 1835.88,1446.38 1788.55,1462.24 210.841,1462.24 210.841,1462.24 \n",
+       "  \" fill=\"#e26f46\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  210.841,1462.24 210.841,933.324 479.051,314.488 488.518,295.447 516.759,252.129 517.705,250.701 520.288,246.926 520.374,246.8 520.641,246.413 521.487,245.185 \n",
+       "  521.776,244.771 530.454,232.394 533.767,228.11 634.74,104.343 682.071,88.4751 2259.78,88.4751 2259.78,617.395 1991.57,1236.23 1982.1,1255.27 1953.86,1298.59 \n",
+       "  1952.92,1300.02 1950.33,1303.79 1950.25,1303.92 1950.01,1304.26 1950.01,1304.27 1949.94,1304.37 1949.91,1304.41 1949.13,1305.53 1948.84,1305.95 1940.17,1318.32 \n",
+       "  1936.85,1322.61 1835.88,1446.38 1788.55,1462.24 210.841,1462.24 \n",
+       "  \"/>\n",
+       "<polygon clip-path=\"url(#clip0102)\" points=\"\n",
+       "210.88,1462.19 210.88,933.268 479.09,314.432 488.557,295.391 516.798,252.072 517.744,250.644 520.327,246.869 520.413,246.744 520.672,246.368 521.449,245.241 \n",
+       "  521.737,244.827 530.415,232.45 533.728,228.166 634.701,104.399 682.032,88.5315 2259.74,88.5315 2259.74,617.451 1991.53,1236.29 1982.06,1255.33 1953.82,1298.65 \n",
+       "  1952.88,1300.07 1950.29,1303.85 1950.21,1303.98 1949.97,1304.31 1949.95,1304.35 1949.17,1305.48 1948.88,1305.89 1940.21,1318.27 1936.89,1322.55 1835.92,1446.32 \n",
+       "  1788.59,1462.19 210.88,1462.19 210.88,1462.19 \n",
+       "  \" fill=\"#3da44d\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  210.88,1462.19 210.88,933.268 479.09,314.432 488.557,295.391 516.798,252.072 517.744,250.644 520.327,246.869 520.413,246.744 520.672,246.368 521.449,245.241 \n",
+       "  521.737,244.827 530.415,232.45 533.728,228.166 634.701,104.399 682.032,88.5315 2259.74,88.5315 2259.74,617.451 1991.53,1236.29 1982.06,1255.33 1953.82,1298.65 \n",
+       "  1952.88,1300.07 1950.29,1303.85 1950.21,1303.98 1949.97,1304.31 1949.95,1304.35 1949.17,1305.48 1948.88,1305.89 1940.21,1318.27 1936.89,1322.55 1835.92,1446.32 \n",
+       "  1788.59,1462.19 210.88,1462.19 \n",
+       "  \"/>\n",
+       "<polygon clip-path=\"url(#clip0102)\" points=\"\n",
+       "211.009,1462 211.009,933.08 479.22,314.244 488.686,295.203 516.927,251.884 517.874,250.456 520.456,246.681 520.542,246.556 521.319,245.429 521.608,245.015 \n",
+       "  530.285,232.639 533.599,228.354 634.572,104.587 681.903,88.7195 2259.61,88.7195 2259.61,617.639 1991.4,1236.47 1981.93,1255.52 1953.69,1298.83 1952.75,1300.26 \n",
+       "  1950.16,1304.04 1950.08,1304.16 1949.3,1305.29 1949.01,1305.7 1940.34,1318.08 1937.02,1322.36 1836.05,1446.13 1788.72,1462 211.009,1462 211.009,1462 \n",
+       "  \n",
+       "  \" fill=\"#c271d2\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  211.009,1462 211.009,933.08 479.22,314.244 488.686,295.203 516.927,251.884 517.874,250.456 520.456,246.681 520.542,246.556 521.319,245.429 521.608,245.015 \n",
+       "  530.285,232.639 533.599,228.354 634.572,104.587 681.903,88.7195 2259.61,88.7195 2259.61,617.639 1991.4,1236.47 1981.93,1255.52 1953.69,1298.83 1952.75,1300.26 \n",
+       "  1950.16,1304.04 1950.08,1304.16 1949.3,1305.29 1949.01,1305.7 1940.34,1318.08 1937.02,1322.36 1836.05,1446.13 1788.72,1462 211.009,1462 \n",
+       "  \n",
+       "  \"/>\n",
+       "<polygon clip-path=\"url(#clip0102)\" points=\"\n",
+       "211.441,1461.37 211.441,932.454 479.651,313.618 489.117,294.577 517.358,251.258 518.305,249.83 520.888,246.055 521.176,245.641 529.854,233.264 533.167,228.98 \n",
+       "  634.14,105.213 681.472,89.3455 2259.18,89.3455 2259.18,618.265 1990.97,1237.1 1981.5,1256.14 1953.26,1299.46 1952.32,1300.89 1949.73,1304.66 1949.44,1305.08 \n",
+       "  1940.77,1317.45 1937.45,1321.74 1836.48,1445.51 1789.15,1461.37 211.441,1461.37 211.441,1461.37 \n",
+       "  \" fill=\"#ac8d18\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  211.441,1461.37 211.441,932.454 479.651,313.618 489.117,294.577 517.358,251.258 518.305,249.83 520.888,246.055 521.176,245.641 529.854,233.264 533.167,228.98 \n",
+       "  634.14,105.213 681.472,89.3455 2259.18,89.3455 2259.18,618.265 1990.97,1237.1 1981.5,1256.14 1953.26,1299.46 1952.32,1300.89 1949.73,1304.66 1949.44,1305.08 \n",
+       "  1940.77,1317.45 1937.45,1321.74 1836.48,1445.51 1789.15,1461.37 211.441,1461.37 \n",
+       "  \"/>\n",
+       "<polygon clip-path=\"url(#clip0102)\" points=\"\n",
+       "212.877,1459.28 212.877,930.359 481.087,311.523 490.553,292.482 518.794,249.164 519.741,247.736 528.418,235.359 531.731,231.075 632.705,107.308 680.036,91.44 \n",
+       "  2257.74,91.44 2257.74,620.36 1989.53,1239.2 1980.07,1258.24 1951.83,1301.56 1950.88,1302.98 1942.2,1315.36 1938.89,1319.64 1837.92,1443.41 1790.58,1459.28 \n",
+       "  212.877,1459.28 212.877,1459.28 \n",
+       "  \" fill=\"#00a9ad\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  212.877,1459.28 212.877,930.359 481.087,311.523 490.553,292.482 518.794,249.164 519.741,247.736 528.418,235.359 531.731,231.075 632.705,107.308 680.036,91.44 \n",
+       "  2257.74,91.44 2257.74,620.36 1989.53,1239.2 1980.07,1258.24 1951.83,1301.56 1950.88,1302.98 1942.2,1315.36 1938.89,1319.64 1837.92,1443.41 1790.58,1459.28 \n",
+       "  212.877,1459.28 \n",
+       "  \"/>\n",
+       "<polygon clip-path=\"url(#clip0102)\" points=\"\n",
+       "217.689,1452.38 217.689,923.457 485.899,304.621 495.365,285.58 523.606,242.261 526.919,237.977 627.893,114.21 675.224,98.3424 2252.93,98.3424 2252.93,627.262 \n",
+       "  1984.72,1246.1 1975.26,1265.14 1947.01,1308.46 1943.7,1312.74 1842.73,1436.51 1795.4,1452.38 217.689,1452.38 217.689,1452.38 \n",
+       "  \" fill=\"#ed5d92\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  217.689,1452.38 217.689,923.457 485.899,304.621 495.365,285.58 523.606,242.261 526.919,237.977 627.893,114.21 675.224,98.3424 2252.93,98.3424 2252.93,627.262 \n",
+       "  1984.72,1246.1 1975.26,1265.14 1947.01,1308.46 1943.7,1312.74 1842.73,1436.51 1795.4,1452.38 217.689,1452.38 \n",
+       "  \"/>\n",
+       "<polygon clip-path=\"url(#clip0102)\" points=\"\n",
+       "233.466,1428.58 233.466,899.656 501.676,280.82 511.142,261.779 612.116,138.011 659.447,122.144 2237.15,122.144 2237.15,651.063 1968.94,1269.9 1959.48,1288.94 \n",
+       "  1858.5,1412.71 1811.17,1428.58 233.466,1428.58 233.466,1428.58 \n",
+       "  \" fill=\"#c68125\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  233.466,1428.58 233.466,899.656 501.676,280.82 511.142,261.779 612.116,138.011 659.447,122.144 2237.15,122.144 2237.15,651.063 1968.94,1269.9 1959.48,1288.94 \n",
+       "  1858.5,1412.71 1811.17,1428.58 233.466,1428.58 \n",
+       "  \"/>\n",
+       "<polygon clip-path=\"url(#clip0102)\" points=\"\n",
+       "288.685,1357.17 288.685,828.251 556.896,209.416 604.227,193.548 2181.94,193.548 2181.94,722.467 1913.72,1341.3 1866.39,1357.17 288.685,1357.17 288.685,1357.17 \n",
+       "  \n",
+       "  \" fill=\"#00a98d\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  288.685,1357.17 288.685,828.251 556.896,209.416 604.227,193.548 2181.94,193.548 2181.94,722.467 1913.72,1341.3 1866.39,1357.17 288.685,1357.17 \n",
+       "  \n",
+       "  \"/>\n",
+       "<polygon clip-path=\"url(#clip0102)\" points=\"\n",
+       "446.456,1039.82 446.456,510.9 2024.16,510.9 2024.16,1039.82 446.456,1039.82 446.456,1039.82 \n",
+       "  \" fill=\"#8e971d\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<polyline clip-path=\"url(#clip0102)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  446.456,1039.82 446.456,510.9 2024.16,510.9 2024.16,1039.82 446.456,1039.82 \n",
+       "  \"/>\n",
+       "</svg>\n"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "using Plots\n",
+    "plot()\n",
+    "for i in 10:-1:1\n",
+    "    plot!(Fs(i, 0))\n",
+    "end\n",
+    "# The cell needs to return the plot for it to be displayed\n",
+    "# but the `for` loop returns `nothing` so we add this dummy `plot!` that returns the plot\n",
+    "plot!()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, suppose we want to compute an invariant set by scaling $F_s$ by the appropriate $\\alpha$.\n",
+    "In equation (11) of [RKKM05], we want to check whether $A^s W \\subseteq \\alpha W$ which is equivalent to $W \\subseteq \\alpha A^{-s} W$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "αo (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function αo(s)\n",
+    "    A_W = A^s \\ W # This triggers the computation of the H-representation of W\n",
+    "    # A_W is H-represented\n",
+    "    hashyperplanes(A_W) && error(\"HyperPlanes not supported\")\n",
+    "    return maximum([Polyhedra.support_function(h.a, W) / h.β for h in halfspaces(A_W)])\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We obtain $\\alpha \\approx 1.9 \\cdot 10^{-5}$ like in [RKKM05]."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.9190700000000013e-5"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "α = αo(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The scaled set is is the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n",
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"600\" height=\"400\" viewBox=\"0 0 2400 1600\">\n",
+       "<defs>\n",
+       "  <clipPath id=\"clip0500\">\n",
+       "    <rect x=\"0\" y=\"0\" width=\"2400\" height=\"1600\"/>\n",
+       "  </clipPath>\n",
+       "</defs>\n",
+       "<polygon clip-path=\"url(#clip0500)\" points=\"\n",
+       "0,1600 2400,1600 2400,0 0,0 \n",
+       "  \" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<defs>\n",
+       "  <clipPath id=\"clip0501\">\n",
+       "    <rect x=\"480\" y=\"0\" width=\"1681\" height=\"1600\"/>\n",
+       "  </clipPath>\n",
+       "</defs>\n",
+       "<polygon clip-path=\"url(#clip0500)\" points=\"\n",
+       "149.361,1503.47 2321.26,1503.47 2321.26,47.2441 149.361,47.2441 \n",
+       "  \" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<defs>\n",
+       "  <clipPath id=\"clip0502\">\n",
+       "    <rect x=\"149\" y=\"47\" width=\"2173\" height=\"1457\"/>\n",
+       "  </clipPath>\n",
+       "</defs>\n",
+       "<polyline clip-path=\"url(#clip0502)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  446.471,1503.47 446.471,47.2441 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0502)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  840.891,1503.47 840.891,47.2441 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0502)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  1235.31,1503.47 1235.31,47.2441 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0502)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  1629.73,1503.47 1629.73,47.2441 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0502)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  2024.15,1503.47 2024.15,47.2441 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0502)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  149.361,1304.27 2321.26,1304.27 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0502)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  149.361,1039.81 2321.26,1039.81 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0502)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  149.361,775.359 2321.26,775.359 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0502)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  149.361,510.905 2321.26,510.905 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0502)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n",
+       "  149.361,246.45 2321.26,246.45 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0500)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  149.361,1503.47 2321.26,1503.47 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0500)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  149.361,1503.47 149.361,47.2441 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0500)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  446.471,1503.47 446.471,1481.63 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0500)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  840.891,1503.47 840.891,1481.63 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0500)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  1235.31,1503.47 1235.31,1481.63 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0500)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  1629.73,1503.47 1629.73,1481.63 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0500)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  2024.15,1503.47 2024.15,1481.63 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0500)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  149.361,1304.27 181.939,1304.27 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0500)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  149.361,1039.81 181.939,1039.81 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0500)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  149.361,775.359 181.939,775.359 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0500)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  149.361,510.905 181.939,510.905 \n",
+       "  \"/>\n",
+       "<polyline clip-path=\"url(#clip0500)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  149.361,246.45 181.939,246.45 \n",
+       "  \"/>\n",
+       "<g clip-path=\"url(#clip0500)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 446.471, 1557.47)\" x=\"446.471\" y=\"1557.47\">-1.0</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0500)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 840.891, 1557.47)\" x=\"840.891\" y=\"1557.47\">-0.5</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0500)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 1235.31, 1557.47)\" x=\"1235.31\" y=\"1557.47\">0.0</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0500)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 1629.73, 1557.47)\" x=\"1629.73\" y=\"1557.47\">0.5</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0500)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 2024.15, 1557.47)\" x=\"2024.15\" y=\"1557.47\">1.0</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0500)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 125.361, 1321.77)\" x=\"125.361\" y=\"1321.77\">-2</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0500)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 125.361, 1057.31)\" x=\"125.361\" y=\"1057.31\">-1</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0500)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 125.361, 792.859)\" x=\"125.361\" y=\"792.859\">0</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0500)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 125.361, 528.405)\" x=\"125.361\" y=\"528.405\">1</text>\n",
+       "</g>\n",
+       "<g clip-path=\"url(#clip0500)\">\n",
+       "<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 125.361, 263.95)\" x=\"125.361\" y=\"263.95\">2</text>\n",
+       "</g>\n",
+       "<polygon clip-path=\"url(#clip0502)\" points=\"\n",
+       "210.829,1462.26 210.829,933.341 479.04,314.505 488.506,295.464 516.747,252.146 517.694,250.718 520.276,246.943 520.363,246.817 520.652,246.396 521.499,245.168 \n",
+       "  521.788,244.754 530.465,232.377 533.778,228.093 634.752,104.326 682.083,88.4582 2259.79,88.4582 2259.79,617.378 1991.58,1236.21 1982.11,1255.25 1953.87,1298.57 \n",
+       "  1952.93,1300 1950.34,1303.78 1950.26,1303.9 1949.92,1304.39 1949.9,1304.42 1949.12,1305.55 1948.83,1305.96 1940.16,1318.34 1936.84,1322.63 1835.87,1446.39 \n",
+       "  1788.54,1462.26 210.829,1462.26 210.829,1462.26 \n",
+       "  \" fill=\"#009af9\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<polyline clip-path=\"url(#clip0502)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n",
+       "  210.829,1462.26 210.829,933.341 479.04,314.505 488.506,295.464 516.747,252.146 517.694,250.718 520.276,246.943 520.363,246.817 520.652,246.396 521.499,245.168 \n",
+       "  521.788,244.754 530.465,232.377 533.778,228.093 634.752,104.326 682.083,88.4582 2259.79,88.4582 2259.79,617.378 1991.58,1236.21 1982.11,1255.25 1953.87,1298.57 \n",
+       "  1952.93,1300 1950.34,1303.78 1950.26,1303.9 1949.92,1304.39 1949.9,1304.42 1949.12,1305.55 1948.83,1305.96 1940.16,1318.34 1936.84,1322.63 1835.87,1446.39 \n",
+       "  1788.54,1462.26 210.829,1462.26 \n",
+       "  \"/>\n",
+       "</svg>\n"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "using Plots\n",
+    "plot((1 - α)^(-1) * Fs(10, 0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.1.0",
+   "language": "julia",
+   "name": "julia-1.1"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.1.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/elements.jl
+++ b/src/elements.jl
@@ -74,6 +74,11 @@ Base.:(*)(α::Real, h::HyperPlane) = HyperPlane(α * h.a, α * h.β)
 Base.:(*)(h::HalfSpace, α::Real) = HalfSpace(h.a * α, h.β * α)
 Base.:(*)(α::Real, h::HalfSpace) = HalfSpace(α * h.a, α * h.β)
 
+function Base.:(/)(h::ElemT, P::UniformScaling) where {T, ElemT<:HRepElement{T}}
+    Tout = _promote_type(T, eltype(P))
+    ElemTout = similar_type(ElemT, FullDim(h), Tout)
+    ElemTout(P * _vec(Tout, h.a), Tout(h.β))
+end
 function Base.:(/)(h::ElemT, P::AbstractMatrix) where {T, ElemT<:HRepElement{T}}
     Tout = _promote_type(T, eltype(P))
     ElemTout = similar_type(ElemT, size(P, 2), Tout)

--- a/src/repelemop.jl
+++ b/src/repelemop.jl
@@ -157,7 +157,7 @@ function _hinv(h::HRepElement, vr::VRep)
 end
 function _hinh(h::HalfSpace, hr::HRep, solver::Solver)
     # ⟨a, x⟩ ≦ β -> if β < max ⟨a, x⟩ then h is outside
-    model = support_function_model(h.a, rep, solver)
+    model = support_function_model(h.a, hr, solver)
     MOI.optimize!(model)
     term = MOI.get(model, MOI.TerminationStatus())
     if term == MOI.DUAL_INFEASIBLE

--- a/src/repelemop.jl
+++ b/src/repelemop.jl
@@ -1,4 +1,4 @@
-export ininterior, inrelativeinterior
+export ininterior, inrelativeinterior, support_function
 
 hyperplane(h::HyperPlane) = h
 hyperplane(h::HalfSpace) = HyperPlane(h.a, h.β)
@@ -117,6 +117,38 @@ Returns whether `p` is in the relative interior of `h`, e.g. in the relative int
 """
 inrelativeinterior(v::VRepElement, hr::HRep) = _vinh(v, hr, inrelativeinterior)
 
+function support_function_model(h::AbstractVector, rep::Rep, solver)
+    length(h) != fulldim(rep) && throw(DimensionMismatch())
+    model, T = layered_optimizer(solver)
+    x = MOI.add_variables(model, fulldim(rep))
+    MOI.add_constraint(model, MOI.VectorOfVariables(x), PolyhedraOptSet(rep))
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),
+            MOI.ScalarAffineFunction(
+                MOI.ScalarAffineTerm{T}.(h, x),
+                zero(T)))
+    return model
+end
+
+"""
+   support_function(h::AbstractVector, rep::Rep, solver=Polyhedra.linear_objective_solver(p))
+
+Return the value of the support function of `rep` at `h`. See [Section 13, R15] for more details.
+
+[R15] Rockafellar, R.T. *Convex analysis*. Princeton university press, **2015**.
+"""
+function support_function(h::AbstractVector, rep::Rep, solver=Polyhedra.linear_objective_solver(rep))
+    model = support_function_model(h, rep, solver)
+    MOI.optimize!(model)
+    term = MOI.get(model, MOI.TerminationStatus())
+    if term == MOI.OPTIMAL
+        return MOI.get(model, MOI.ObjectiveValue())
+    else
+        error("Cannot determine the value of the support function at $h",
+              " because the linear program terminated with status $term.")
+    end
+end
+
 function _hinv(h::HRepElement, vr::ElemIt{<:VRepElement})
     all(in.(vr, h))
 end
@@ -125,14 +157,7 @@ function _hinv(h::HRepElement, vr::VRep)
 end
 function _hinh(h::HalfSpace, hr::HRep, solver::Solver)
     # ⟨a, x⟩ ≦ β -> if β < max ⟨a, x⟩ then h is outside
-    model, T = layered_optimizer(solver)
-    x = MOI.add_variables(model, fulldim(hr))
-    MOI.add_constraint(model, MOI.VectorOfVariables(x), PolyhedraOptSet(hr))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),
-            MOI.ScalarAffineFunction(
-                MOI.ScalarAffineTerm{T}.(h.a, x),
-                zero(T)))
+    model = support_function_model(h.a, rep, solver)
     MOI.optimize!(model)
     term = MOI.get(model, MOI.TerminationStatus())
     if term == MOI.DUAL_INFEASIBLE

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -8,6 +8,7 @@ include("empty.jl")
 include("sparse.jl")
 include("sparserect.jl")
 include("recipe.jl")
+include("support_function.jl")
 
 const misctests = Dict("basic" => basictest,
                        "doc" => doctest,
@@ -18,6 +19,7 @@ const misctests = Dict("basic" => basictest,
                        "empty" => emptytest,
                        "sparse" => sparsetest,
                        "sparserect" => sparserecttest,
-                       "recipe" => recipetest)
+                       "recipe" => recipetest,
+                       "support_function" => support_function_test)
 
 @polytestset misc

--- a/test/support_function.jl
+++ b/test/support_function.jl
@@ -1,0 +1,26 @@
+function support_function_test(p::Rep)
+    @test support_function([1, 1], p) ≈ 1
+    @test support_function([1, 0], p) ≈ 1
+    @testset "Scale" begin
+        @test support_function([1, 1], 2p) ≈ 2
+        @test support_function([1, 0], 2p) ≈ 2
+    end
+end
+function support_function_test(lib::Polyhedra.Library)
+    v = convexhull([1, 0], [0, 1], [-1, -1])
+    @testset "V-representation" begin
+        support_function_test(v)
+    end
+    p = polyhedron(v, lib)
+    @testset "Polyhedron with V-representation" begin
+        support_function_test(p)
+    end
+    @test !hrepiscomputed(p)
+    h = hrep(polyhedron(v, lib))
+    # We don't test just with the H-rep since it needs a solver
+    p = polyhedron(h, lib)
+    @testset "Polyhedron with H-representation" begin
+        support_function_test(p)
+    end
+    @test !vrepiscomputed(p)
+end


### PR DESCRIPTION
When given a V-representation or a polyhedron with the V-representation computed, the solver chosen is the V-rep solver which solves the LP by iterating over all vertices and rays.
When given a H-representation, it uses the LP solver given or the default one of the library.