### PR TITLE
Adds MOI.LOCALLY_SOLVED as an acceptable return code for hchebyshevcenter()

### DIFF
--- a/src/center.jl
+++ b/src/center.jl
@@ -26,7 +26,7 @@ function hchebyshevcenter(p::HRep, solver=Polyhedra.default_solver(p; T=Float64)
     JuMP.@objective(model, Max, minr)
     JuMP.optimize!(model)
     term = JuMP.termination_status(model)
-    if term != MOI.OPTIMAL
+    if term ∉ [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
         if term == MOI.INFEASIBLE
             error("An empty polyhedron has no H-Chebyshev center.")
         elseif term == MOI.DUAL_INFEASIBLE
@@ -41,7 +41,7 @@ function hchebyshevcenter(p::HRep, solver=Polyhedra.default_solver(p; T=Float64)
     JuMP.@objective(model, Min, maxr)
     JuMP.optimize!(model)
     term = JuMP.termination_status(model)
-    if term == MOI.OPTIMAL
+    if term ∈ [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
         return (JuMP.value.(c), JuMP.value(minr))
     else
         error("Solver returned $term when computing the H-Chebyshev center.")


### PR DESCRIPTION
Example code for the matter:
```julia
hchebyshevcenter(polyhedron(vrep(rand(10, 3))), with_optimizer(Ipopt.Optimizer, print_level=0))
```
Output **before** change:
```julia
Solver returned LOCALLY_SOLVED when computing the H-Chebyshev center.

Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] hchebyshevcenter(::DefaultPolyhedron{Float64,MixedMatHRep{Float64,Array{Float64,2}},MixedMatVRep{Float64,Array{Float64,2}}}, ::OptimizerFactory) at /home/henrique/.julia/dev/Polyhedra/src/center.jl:35
 [3] top-level scope at In[92]:1
```
Output **after** change:
```
([0.664083, 0.515307, 0.583585], 0.270949718678351)
```
