### PR TITLE
Specialized planar convex hull

### DIFF
--- a/src/Polyhedra.jl
+++ b/src/Polyhedra.jl
@@ -77,6 +77,7 @@ include("matrep.jl")
 include("liftedrep.jl")
 include("doubledescription.jl") # FIXME move it after projection.jl once it stops depending on LiftedRep
 include("interval.jl") # 1D polyhedron
+include("planar.jl")
 include("defaultlibrary.jl")
 
 include("fulldim.jl")

--- a/src/decompose.jl
+++ b/src/decompose.jl
@@ -92,10 +92,10 @@ function fulldecompose(poly_geom::Mesh{3}, ::Type{T}) where T
                 return
             end
             @assert length(rays) <= 2
-            if length(rays) == 2
-                push!(hull, exit_point(last(hull), last(rays)))
-            end
-            if length(rays) == 1
+            if !isempty(rays)
+                if length(rays) + length(hull) >= 2
+                    push!(hull, exit_point(last(hull), last(rays)))
+                end
                 push!(hull, exit_point(first(hull), first(rays)))
             end
         else

--- a/src/decompose.jl
+++ b/src/decompose.jl
@@ -42,7 +42,8 @@ function scene(vr::VRep, ::Type{T}) where T
                                                 (zmin + zmax) / 2 - width],
                                                2 * width * ones(T, 3))
     # Intersection of rays with the limits of the scene
-    (start, ray) -> begin
+    (start, r) -> begin
+        ray = coord(r)
         times = max.((Vector(minimum(scene))-start) ./ ray, (Vector(maximum(scene))-start) ./ ray)
         times[ray .== 0] .= Inf # To avoid -Inf with .../(-0)
         time = minimum(times)

--- a/src/decompose.jl
+++ b/src/decompose.jl
@@ -85,7 +85,7 @@ function fulldecompose(poly_geom::Mesh{3}, ::Type{T}) where T
                 push!(face_vert, x)
             end
         end
-        hull, lines, rays = _planar_hull(3, face_vert, incidentlines(poly, hidx), incidentrays(poly, hidx), r -> cross(zray, r))
+        hull, lines, rays = _planar_hull(3, face_vert, incidentlines(poly, hidx), incidentrays(poly, hidx), counterclockwise, r -> cross(zray, r))
         if isempty(lines)
             if length(hull) + length(rays) < 3
                 return

--- a/src/decompose.jl
+++ b/src/decompose.jl
@@ -79,107 +79,67 @@ function fulldecompose(poly_geom::Mesh{3}, ::Type{T}) where T
 
         # Checking rays
         counterclockwise(a, b) = dot(cross(a, b), zray)
-        line = nothing
-        lineleft = false
-        lineright = false
-        function checkleftright(r::Union{Ray, Line})
-            cc = counterclockwise(r, line)
-            if !isapproxzero(cc)
-                if cc < 0 || islin(r)
-                    lineleft = true
-                end
-                if cc > 0 || islin(r)
-                    lineright = true
-                end
-            end
-        end
-        for l in incidentlines(poly, hidx)
-            if !isapproxzero(l)
-                if line === nothing
-                    line = l
-                else
-                    checkleftright(l)
-                end
-            end
-        end
-        for r in incidentrays(poly, hidx)
-            if !isapproxzero(r)
-                if line === nothing
-                    if xray === nothing || counterclockwise(r, xray) > 0
-                        xray = coord(r) # r is more right than xray
-                    end
-                    if yray === nothing || counterclockwise(r, yray) < 0
-                        yray = coord(r) # r is more left than xray
-                    end
-                else
-                    checkleftright(r)
-                end
-            end
-        end
-
-        # Checking vertices
         face_vert = pointtype(poly)[]
         for x in points(poly)
             if _isapprox(dot(x, zray), h.β)
                 push!(face_vert, x)
             end
         end
-
-        if line !== nothing
-            if isempty(face_vert)
-                center = origin(pointtype(poly), 3)
-            else
-                center = first(face_vert)
-            end
-            hull = pointtype(poly)[]
-            push!(hull, exit_point(center, line))
-            if lineleft
-                push!(hull, exit_point(center, cross(zray, line)))
-            end
-            push!(hull, exit_point(center, -line))
-            if lineright
-                push!(hull, exit_point(center, cross(line, zray)))
-            end
-            hulls = (hull,)
-        else
-            #if length(face_vert) < 3 # Wrong, they are also the rays
-            #  error("Not enough vertices and rays to form a face, it may be because of numerical rounding. Otherwise, please report this bug.")
-            #end
-            if length(face_vert) < 3 && (xray == nothing || (length(face_vert) < 2 && (yray == xray || length(face_vert) < 1)))
+        hull, lines, rays = _planar_hull(3, face_vert, incidentlines(poly, hidx), incidentrays(poly, hidx), r -> cross(zray, r))
+        if isempty(lines)
+            if length(hull) + length(rays) < 3
                 return
             end
-            if xray == nothing
-                sweep_norm = cross(zray, [1,0,0])
-                if sum(abs, sweep_norm) == 0
-                    sweep_norm = cross(zray, [0,1,0])
-                end
-            else
-                sweep_norm = cross(zray, xray)
+            @assert length(rays) <= 2
+            if length(rays) == 2
+                push!(hull, exit_point(last(hull), last(rays)))
             end
-            sort!(face_vert, by = x -> dot(x, sweep_norm))
-            xtoy_hull = getsemihull(face_vert, 1, counterclockwise, yray)
-            if yray == nothing
-                ytox_hull = getsemihull(face_vert, -1, counterclockwise, yray)
-            else
-                ytox_hull = Any[]
-                push!(ytox_hull, face_vert[1])
-                if last(xtoy_hull) != face_vert[1]
-                    push!(ytox_hull, last(xtoy_hull))
-                end
-                push!(ytox_hull, exit_point(last(xtoy_hull), yray))
-                push!(ytox_hull, exit_point(face_vert[1], xray))
+            if length(rays) == 1
+                push!(hull, exit_point(first(hull), first(rays)))
             end
-            hulls = (xtoy_hull, ytox_hull)
+        else
+            if length(hull) == 2
+                @assert length(lines) == 1 && isempty(rays)
+                a, b = hull
+                line = first(lines)
+                empty!(hull)
+                push!(hull, exit_point(a, line))
+                push!(hull, exit_point(a, -line))
+                push!(hull, exit_point(b, -line))
+                push!(hull, exit_point(b, line))
+            else
+                @assert length(hull) == 1 && isempty(rays)
+                center = first(hull)
+                empty!(hull)
+                a = first(lines)
+                b = nothing
+                if length(lines) == 2
+                    @assert isempty(rays)
+                    b = last(lines)
+                elseif !isempty(rays)
+                    @assert length(lines) == 1
+                    @assert length(rays) == 1
+                    b = linearize(first(rays))
+                end
+                push!(hull, exit_point(center, a))
+                if b !== nothing
+                    push!(hull, exit_point(center, b))
+                end
+                push!(hull, exit_point(center, -a))
+                if b !== nothing && length(lines) == 2 || length(rays) >= 2
+                    @assert length(rays) == 2
+                    push!(hull, exit_point(center, -b))
+                end
+            end
         end
-        for hull in hulls
-            if length(hull) >= 3
-                a = pop!(hull)
-                b = pop!(hull)
-                while !isempty(hull)
-                    c = pop!(hull)
-                    push!(triangles, ((a,b,c), zray))
-                    b = c
-                end
+
+        if length(hull) >= 3
+            a = pop!(hull)
+            b = pop!(hull)
+            while !isempty(hull)
+                c = pop!(hull)
+                push!(triangles, ((a, b, c), zray))
+                b = c
             end
         end
     end

--- a/src/planar.jl
+++ b/src/planar.jl
@@ -1,0 +1,142 @@
+function getsemihull(ps::Vector{PT}, sign_sense, counterclockwise, yray::Nothing = nothing) where PT
+    hull = PT[]
+    if length(ps) == 0
+        return hull
+    end
+    prev = sign_sense == 1 ? first(ps) : last(ps)
+    cur = prev
+    for j in (sign_sense == 1 ? (2:length(ps)) : ((length(ps)-1):-1:1))
+        while prev != cur && counterclockwise(cur - prev, ps[j] - prev) >= 0
+            cur = prev
+            pop!(hull)
+            if !isempty(hull)
+                prev = last(hull)
+            end
+        end
+        push!(hull, cur)
+        prev = cur
+        cur = ps[j]
+    end
+    push!(hull, cur)
+    return hull
+end
+
+function getsemihull(ps::Vector{PT}, sign_sense, counterclockwise, yray) where PT
+    hull = getsemihull(ps, sign_sense, counterclockwise)
+    while length(hull) >= 2 && counterclockwise(hull[end] - hull[end - 1], yray) >= 0
+        pop!(hull)
+    end
+    return hull
+end
+
+function _planar_hull(d::FullDim, points, lines, rays, counterclockwise, rotate)
+    line = nothing
+    lineleft = false
+    lineright = false
+    function checkleftright(r::Union{Ray, Line})
+        cc = counterclockwise(r, line)
+        if !isapproxzero(cc)
+            if cc < 0 || islin(r)
+                lineleft = true
+            end
+            if cc > 0 || islin(r)
+                lineright = true
+            end
+        end
+    end
+    for l in lines
+        if !isapproxzero(l)
+            if line === nothing
+                line = l
+            else
+                checkleftright(l)
+            end
+        end
+    end
+    xray = yray = nothing
+    for r in rays
+        isapproxzero(r) && continue
+        if line === nothing
+            if xray === nothing
+                xray = yray = coord(r)
+            else
+                if Line(xray) ≈ linearize(r) && !(Ray(xray) ≈ r)
+                    line = Line(xray)
+                    checkleftright(Ray(yray))
+                elseif Line(yray) ≈ linearize(r) && !(Ray(yray) ≈ r)
+                    line = Line(yray)
+                    checkleftright(Ray(xray))
+                else
+                    x_right = counterclockwise(r, xray) > 0
+                    y_left = counterclockwise(r, yray) < 0
+                    if x_right
+                        if y_left
+                            line = Line(xray)
+                            lineleft = lineright = true
+                        else
+                            xray = coord(r)
+                        end
+                    else
+                        if y_left
+                            yray = coord(r)
+                        end
+                    end
+                end
+            end
+        else
+            checkleftright(r)
+        end
+    end
+    if line === nothing
+        if xray === nothing
+            sweep_norm = rotate(basis(eltype(points), d, 1))
+            if iszero(sum(abs, sweep_norm))
+                sweep_norm = rotate(basis(eltype(points), d, 2))
+            end
+        else
+            sweep_norm = rotate(xray)
+        end
+    else
+        sweep_norm = rotate(coord(line))
+    end
+    sort!(points, by = x -> dot(x, sweep_norm))
+    _points = eltype(points)[]
+    _lines = eltype(lines)[]
+    _rays = eltype(rays)[]
+    if line === nothing
+        append!(_points, getsemihull(points, 1, counterclockwise, yray))
+        if yray === nothing
+            append!(_points, getsemihull(points, -1, counterclockwise, yray)[2:end-1])
+        else
+            push!(_rays, Ray(xray))
+            if !(Ray(xray) ≈ Ray(yray))
+                push!(_rays, Ray(yray))
+            end
+        end
+    else
+        push!(_lines, line)
+        push!(_points, first(points))
+        if lineleft
+            if lineright
+                push!(_lines, Line(sweep_norm))
+            else
+                push!(_rays, Ray(sweep_norm))
+            end
+        elseif lineright
+            push!(_rays, Ray(-sweep_norm))
+        else
+            if !(dot(first(points), sweep_norm) ≈ dot(last(points), sweep_norm))
+                push!(_points, last(points))
+            end
+        end
+    end
+    return _points, _lines, _rays
+end
+
+counterclockwise(x, y) = x[1] * y[2] - x[2] * y[1]
+rotate(x) = convert(typeof(x), StaticArrays.SVector(-x[2], x[1]))
+
+function planar_hull(vr::VRepresentation)
+    d = FullDim(vr)
+    vrep(_planar_hull(FullDim(vr), collect(points(vr)), lines(vr), rays(vr), counterclockwise, rotate)...; d = d)
+end

--- a/src/recipe.jl
+++ b/src/recipe.jl
@@ -1,32 +1,5 @@
 using RecipesBase
 
-function getsemihull(ps::Vector{PT}, sign_sense, counterclockwise, yray = nothing) where PT
-    hull = PT[]
-    if length(ps) == 0
-        return hull
-    end
-    prev = sign_sense == 1 ? first(ps) : last(ps)
-    cur = prev
-    for j in (sign_sense == 1 ? (2:length(ps)) : ((length(ps)-1):-1:1))
-        while prev != cur && counterclockwise(cur - prev, ps[j] - prev) >= 0
-            cur = prev
-            pop!(hull)
-            if !isempty(hull)
-                prev = last(hull)
-            end
-        end
-        if yray !== nothing && counterclockwise(ps[j] - cur, yray) >= 0
-            break
-        else
-            push!(hull, cur)
-            prev = cur
-            cur = ps[j]
-        end
-    end
-    push!(hull, cur)
-    hull
-end
-
 function planar_contour(p::Polyhedron)
     if fulldim(p) != 2
         if fulldim(p) == 3

--- a/src/redundancy.jl
+++ b/src/redundancy.jl
@@ -56,6 +56,9 @@ but are not in the relative interior either, may be kept.
 """
 function removevredundancy! end
 function removevredundancy!(p::Polyhedron; strongly=false)
+    if fulldim(p) == 2
+        setvrep!(p, planar_hull(vrep(p)))
+    end
     solver = nothing
     if !strongly && !hrepiscomputed(p) && supportssolver(typeof(p))
         solver = default_solver(p)

--- a/src/redundancy.jl
+++ b/src/redundancy.jl
@@ -45,7 +45,7 @@ function to remove this warning.
 end
 
 """
-    removevredundancy!(p::VRep; strongly=false)
+    removevredundancy!(p::VRep; strongly=false, planar=true)
 
 Removes the elements of the V-representation of `p` that can be removed without
 changing the polyhedron represented by `p`. That is, it only keeps the extreme
@@ -53,10 +53,12 @@ points and rays. This operation is often called "convex hull" as the remaining
 points are the extreme points of the convex hull of the initial set of points.
 If `strongly=true`, weakly redundant points, i.e., points that are not extreme
 but are not in the relative interior either, may be kept.
+If `fulldim(p)` is 2, `strongly` is `false` and `planar` is `true`, a planar convex hull algorithm
+is used.
 """
 function removevredundancy! end
-function removevredundancy!(p::Polyhedron; strongly=false)
-    if fulldim(p) == 2
+function removevredundancy!(p::Polyhedron; strongly=false, planar=true)
+    if fulldim(p) == 2 && !strongly && planar
         setvrep!(p, planar_hull(vrep(p)))
     end
     solver = nothing

--- a/test/planar.jl
+++ b/test/planar.jl
@@ -1,0 +1,68 @@
+using Test
+using StaticArrays
+using Polyhedra
+
+function test_planar_square(VT, d)
+    ei = ntuple(i -> Polyhedra.basis(VT, d, i), 2)
+    so = -ei[1] + ei[2]
+    no = -ei[1] - ei[2]
+    ne = ei[1] - ei[2]
+    se = ei[1] + ei[2]
+    expected = [no, so, se, ne]
+    for ps in [
+        [no, so, ne, se],
+        [no, se, so, ne],
+        [se, so, no, ne],
+        expected
+    ]
+        hull = Polyhedra.planar_hull(vrep(ps))
+        @test collect(points(hull)) == expected
+        @test !hasallrays(hull)
+        v = vrep(ps) + conichull(se)
+        hull = Polyhedra.planar_hull(v)
+        @test collect(points(hull)) == [ne, no, so]
+        @test collect(rays(hull)) == [Ray(se)]
+        @test !haslines(hull)
+        v = vrep(ps) + conichull(se, se)
+        hull = Polyhedra.planar_hull(v)
+        @test collect(points(hull)) == [ne, no, so]
+        @test collect(rays(hull)) == [Ray(se)]
+        @test !haslines(hull)
+        ne = ei[1] - ei[2]
+        for v in [vrep(ps) + conichull(se, ne),
+                  vrep(ps) + conichull(se, ne, ei[1])]
+            hull = Polyhedra.planar_hull(v)
+            @test collect(points(hull)) == [no, so]
+            @test collect(rays(hull)) == [Ray(ne), Ray(se)]
+            @test !haslines(hull)
+        end
+        v = vrep(ps) + conichull(se, ne, -se)
+        hull = Polyhedra.planar_hull(v)
+        @test collect(points(hull)) == [ne]
+        @test collect(rays(hull)) == [Ray(ne)]
+        @test collect(lines(hull)) == [Line(se)]
+        for v in [vrep(ps) + conichull(se, ne, -ne),
+                  vrep(ps) + conichull(se, Line(ne)),
+                  vrep(ps) + conichull(ne, se, -ne)]
+            hull = Polyhedra.planar_hull(v)
+            @test collect(points(hull)) == [no]
+            @test collect(rays(hull)) == [Ray(se)]
+            @test collect(lines(hull)) == [Line(ne)]
+        end
+        for v in [vrep(ps) + conichull(se, ne, -ne, -se),
+                  vrep(ps) + conichull(se, ne, -ei[1])]
+            hull = Polyhedra.planar_hull(v)
+            @test collect(points(hull)) == [no]
+            @test !hasrays(hull)
+            @test collect(lines(hull)) == [Line(ne), Line(se)]
+        end
+    end
+end
+
+@testset "Planar" begin
+    for T in [Float64, Int]
+        for (VT, d) in [(Vector{T}, 2), (SVector{2, T}, StaticArrays.Size(2))]
+            test_planar_square(VT, d)
+        end
+    end
+end

--- a/test/redundancy.jl
+++ b/test/redundancy.jl
@@ -286,7 +286,7 @@ include("solvers.jl")
             @test collect(points(p)) == [[-1, 0], [0, -1]]
             @test !haslines(p)
             @test collect(rays(p)) == [Ray([1, 1]), Ray([-1, 1])]
-            removevredundancy!(p)
+            removevredundancy!(p, planar=false)
             @test collect(points(p)) == [[0, -1]]
             @test !haslines(p)
             @test collect(rays(p)) == [Ray([1, 1]), Ray([-1, 1])]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ include("representation.jl")
 include("polyhedron.jl")
 
 include("redundancy.jl")
+include("planar.jl")
 include("doubledescription.jl")
 
 include("interval.jl")


### PR DESCRIPTION
The 3D decomposition had a computation of the convex hull of the 2D facets that also supports rays and lines for a while, this PR extracts it as a separate `planar_hull` that is now called in `removevredundancy!` for 2D polyhedra.