### PR TITLE
Implement named dimensions

### DIFF
--- a/src/center.jl
+++ b/src/center.jl
@@ -105,11 +105,11 @@ end
 
 If `p` is a H-representation or is a polyhedron for which the H-representation has already been computed, calls `hchebyshevcenter`, otherwise, call `vchebyshevcenter`.
 """
-function chebyshevcenter(p::Polyhedron, solver=Polyhedra.default_solver(p; T=Float64))
+function chebyshevcenter(p::Polyhedron, solver=Polyhedra.default_solver(p; T=Float64); kws...)
     if hrepiscomputed(p)
-        hchebyshevcenter(p, solver)
+        hchebyshevcenter(p, solver; kws...)
     else
-        vchebyshevcenter(p, solver)
+        vchebyshevcenter(p, solver; kws...)
     end
 end
 chebyshevcenter(p::HRepresentation, solver=Polyhedra.default_solver(p; T=Float64)) = hchebyshevcenter(p, solver)

--- a/src/lphrep.jl
+++ b/src/lphrep.jl
@@ -169,8 +169,10 @@ function startindex(idxs::HIndices{T, LPHRep{T}}) where {T}
 end
 function Base.get(rep::LPHRep{T}, idx::HIndex{T}) where {T}
     ci = constraint_indices(rep, idx)[idx.value]
-    func = MOI.get(rep.model, MOI.ConstraintFunction(), ci)::MOI.ScalarAffineFunction
-    indices = [t.variable_index.value for t in func.terms]
+    func = MOI.get(rep.model, MOI.ConstraintFunction(), ci)::MOI.ScalarAffineFunction{T}
+    # MOI uses `Int64` but `SparseArrays` uses `Int32` by default so `Int64` will create
+    # issues with, e.g. preimages with `spzeros(d, n)`, etc...
+    indices = Int[t.variable_index.value for t in func.terms]
     values = [t.coefficient for t in func.terms]
     a = sparsevec(indices, values, FullDim(rep))
     set = MOI.get(rep.model, MOI.ConstraintSet(), ci)

--- a/src/repop.jl
+++ b/src/repop.jl
@@ -147,7 +147,15 @@ function hcartesianproduct(p1::HRep, p2::HRep)
     d = sum_fulldim(FullDim(p1), FullDim(p2))
     T = promote_coefficient_type((p1, p2))
     f = (i, x) -> zeropad(x, i == 1 ? FullDim(p2) : neg_fulldim(FullDim(p1)))
-    similar((p1, p2), d, T, hmap(f, d, T, p1, p2)...)
+    function dimension_map(i)
+        if i <= fulldim(p1)
+            return (1, i)
+        else
+            return (2, i - fulldim(p1))
+        end
+    end
+    similar((p1, p2), d, T, hmap(f, d, T, p1, p2)...;
+            dimension_map = dimension_map)
 end
 function vcartesianproduct(p1::VRep, p2::VRep)
     d = sum_fulldim(FullDim(p1), FullDim(p2))
@@ -187,7 +195,8 @@ Base.:(\)(P::Union{AbstractMatrix, UniformScaling}, rep::HRep) = rep / P'
 function linear_preimage_transpose(P, p::HRep{Tin}, d) where Tin
     f = (i, h) -> h / P
     T = _promote_type(Tin, eltype(P))
-    return similar(p, d, T, hmap(f, d, T, p)...)
+    return similar(p, d, T, hmap(f, d, T, p)...,
+                   dimension_map = i -> nothing)
 end
 
 """

--- a/src/tmp.jl
+++ b/src/tmp.jl
@@ -1,9 +1,3 @@
-struct ProjectionOptSet{T, RepT<:Rep{T}, I} <: MOI.AbstractVectorSet
-    p::Projection{RepT, I}
-end
-MOI.dimension(set::ProjectionOptSet) = fulldim(set.p)
-Base.copy(set::ProjectionOptSet) = set
-
 struct ProjectionBridge{T, F, RepT, I} <: MOI.Bridges.Constraint.AbstractBridge
     variables::Vector{MOI.VariableIndex}
     constraint::MOI.ConstraintIndex{F, PolyhedraOptSet{T, RepT}}
@@ -57,9 +51,9 @@ function MOI.delete(model::MOI.ModelLike, b::ProjectionBridge)
         MOI.delete(model, vi)
     end
 end
-_moi_set(set::Projection) = ProjectionOptSet(set)
+
 function JuMP.build_constraint(error_fun::Function, func, set::Projection)
     return JuMP.BridgeableConstraint(JuMP.BridgeableConstraint(
-        JuMP.build_constraint(error_fun, func, _moi_set(set)),
+        JuMP.build_constraint(error_fun, func, ProjectionOptSet(set)),
         ProjectionBridge), PolyhedraToLPBridge)
 end

--- a/test/dimension_names.jl
+++ b/test/dimension_names.jl
@@ -1,0 +1,17 @@
+using SparseArrays, Test, JuMP, Polyhedra
+
+function _hypercube(n, base_name)
+    model = Model()
+    @variable(model, [1:n], lower_bound = 0, upper_bound = 1, base_name = base_name)
+    h = hrep(model)
+    @test dimension_names(h) == ["$base_name[$i]" for i in 1:n]
+    return h
+end
+function hypercube_name()
+    h = _hypercube(1, "x") * _hypercube(2, "y")
+    @test dimension_names(h) == ["x[1]", "y[1]", "y[2]"]
+    @test dimension_names(spzeros(3, 4) \ h) === nothing
+end
+@testset "Hypercube name" begin
+    hypercube_name()
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ include("solvers.jl")
 include("elements.jl")
 include("comp.jl")
 include("representation.jl")
+include("dimension_names.jl")
 include("polyhedron.jl")
 
 include("redundancy.jl")


### PR DESCRIPTION
The `LPHRep` use a MathOptInterface model to encode the H-representation.
As this model natively supports naming the variables, `LPHRep` actually supports naming the dimensions.
This PR allows to retrieve these, pass these names along through transformations and sets these names to JuMP variables if the H-representation is used to create a vector of JuMP variables.