### PR TITLE
Fix performance issue in redundancy removal

### DIFF
--- a/src/opt.jl
+++ b/src/opt.jl
@@ -157,7 +157,7 @@ _optimize!(model::JuMP.Model) = JuMP.optimize!(model)
 _optimize!(model::MOI.ModelLike) = MOI.optimize!(model)
 
 function _unknown_status(model, status, message)
-    error("Solver returned ", status, " when ", message, " Solver specific status: ", MOI.get(model, MOI.RawStatusString()))
+    error("Solver returned `", status, "` when ", message, " Solver specific status: ", MOI.get(model, MOI.RawStatusString()))
 end
 function is_feasible(model, message)
     @assert MOI.get(model, MOI.ObjectiveSense()) == MOI.FEASIBILITY_SENSE

--- a/test/dummy_optimizer.jl
+++ b/test/dummy_optimizer.jl
@@ -1,0 +1,9 @@
+using JuMP
+struct DummyOptimizer <: MOI.AbstractOptimizer end
+MOI.is_empty(::DummyOptimizer) = true
+MOI.supports_constraint(::DummyOptimizer, ::Type{<:MOI.AbstractFunction}, ::Type{<:MOI.AbstractSet}) = true
+function MOI.optimize!(::DummyOptimizer, model::MOI.ModelLike)
+    return MOI.Utilities.identity_index_map(model), false
+end
+MOI.get(::DummyOptimizer, ::MOI.TerminationStatus) = MOI.OTHER_ERROR
+MOI.get(::DummyOptimizer, ::MOI.RawStatusString) = "Dummy status"

--- a/test/redundancy.jl
+++ b/test/redundancy.jl
@@ -5,6 +5,7 @@ using StaticArrays
 using Polyhedra
 
 include("solvers.jl")
+include("dummy_optimizer.jl")
 
 @testset "Redundancy removal" begin
     @testset "LP-based" begin
@@ -308,6 +309,11 @@ include("solvers.jl")
 #        @test !haslines(vr)
 #        @test collect(rays(vr)) == [Ray([-1, 1])]
 #    end
+        @testset "Solver error in redundancy" begin
+            vr = convexhull([1.0, 0.0], [0.0, 1.0])
+            err = ErrorException("Solver returned `OTHER_ERROR` when attempting to determine whether `[1.0, 0.0]` of index `Polyhedra.Index{Float64, Vector{Float64}}(1)` is redundant. Solver specific status: Dummy status")
+            @test_throws err removevredundancy(vr, DummyOptimizer)
+        end
     end
 end
 @testset "Duplicate removal" begin


### PR DESCRIPTION
For the example of https://github.com/JuliaPolyhedra/Polyhedra.jl/issues/279, this PR gives almost a 10x speedup!
Before:
```
0.159333 seconds (63.51 k allocations: 8.252 MiB)
```
After:
```
0.018471 seconds (10.34 k allocations: 909.406 KiB)
```


Closes https://github.com/JuliaPolyhedra/Polyhedra.jl/issues/279