### PR TITLE
Fix Interval setvrep and speed up redundancy removal

### DIFF
--- a/src/defaultlibrary.jl
+++ b/src/defaultlibrary.jl
@@ -113,25 +113,29 @@ end
 # Fallback to avoid breaking library adding this new `red` arg.
 # TODO We should remove these fallbacks in the future
 sethrep!(p, h, red) = sethrep!(p, h)
-setvrep!(p, v, red) = sethrep!(p, v)
+setvrep!(p, v, red) = setvrep!(p, v)
 resethrep!(p, h, red) = resethrep!(p, h)
-resetvrep!(p, v, red) = resethrep!(p, v)
+resetvrep!(p, v, red) = resetvrep!(p, v)
 
 function sethrep!(p::DefaultPolyhedron, h::HRepresentation, redundancy = UNKNOWN_REDUNDANCY)
     p.hrep = h
     p.hred = redundancy
+    return
 end
 function setvrep!(p::DefaultPolyhedron, v::VRepresentation, redundancy = UNKNOWN_REDUNDANCY)
     p.vrep = v
     p.vred = redundancy
+    return
 end
 function resethrep!(p::DefaultPolyhedron, h::HRepresentation, redundancy = UNKNOWN_REDUNDANCY)
     p.hrep = h
     p.hred = redundancy
     p.vrep = nothing
+    return
 end
 function resetvrep!(p::DefaultPolyhedron, v::VRepresentation, redundancy = UNKNOWN_REDUNDANCY)
     p.vrep = v
     p.vred = redundancy
     p.hrep = nothing
+    return
 end

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -136,7 +136,7 @@ function _hinterval(rep::HRep{T}, ::Type{AT}, D) where {T, AT}
     return Interval{T, AT, D}(_hinterval(rep, AT)...)
 end
 
-function _vinterval(v::VRep{T}, ::Type{AT}, D) where {T, AT}
+function _vinterval(v::VRep{T}, ::Type{AT}) where {T, AT}
     haslb = true
     lb = zero(T)
     hasub = true
@@ -171,7 +171,11 @@ function _vinterval(v::VRep{T}, ::Type{AT}, D) where {T, AT}
             end
         end
     end
-    Interval{T, AT, D}(haslb, lb, hasub, ub, isempty)
+    return _interval(AT, haslb, lb, hasub, ub, isempty)
+end
+
+function _vinterval(rep::VRep{T}, ::Type{AT}, D) where {T, AT}
+    return Interval{T, AT, D}(_vinterval(rep, AT)...)
 end
 
 Interval{T, AT, D}(p::HRepresentation{T}) where {T, AT, D} = _hinterval(p, AT, D)
@@ -195,15 +199,24 @@ hrepiscomputed(::Interval) = true
 vrepiscomputed(::Interval) = true
 
 # Nothing to do
-function detecthlinearity!(::Interval) end
-function detectvlinearity!(::Interval) end
-function removehredundancy!(::Interval) end
-function removevredundancy!(::Interval) end
+function detecthlinearity!(::Interval, args...; kws...) end
+function detectvlinearity!(::Interval, args...; kws...) end
+function removehredundancy!(::Interval, args...; kws...) end
+function removevredundancy!(::Interval, args...; kws...) end
 
-function sethrep!(p::Interval{T, AT}, h::HRep) where {T, AT}
+sethrep!(p::Interval, h::HRep) = resethrep!(p, h)
+function resethrep!(p::Interval{T, AT}, h::HRep) where {T, AT}
     hnew, v, volume = _hinterval(h, AT)
     p.hrep = hnew
     p.vrep = v
     p.length = volume
     return p
-end    
+end
+setvrep!(p::Interval, v::VRep) = resetvrep!(p, v)
+function resetvrep!(p::Interval{T, AT}, v::VRep) where {T, AT}
+    h, vnew, volume = _vinterval(v, AT)
+    p.hrep = h
+    p.vrep = vnew
+    p.length = volume
+    return p
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -92,3 +92,8 @@ function generator_fulltest(p::Polyhedron, vrepargs...)
     removevredundancy!(p)
     generator_fulltest(vrep(p), vrepargs...)
 end
+
+function alloc_test(f, n)
+    f() # compile
+    @test n == @allocated f()
+end


### PR DESCRIPTION
When arguments where given, the redundancy removal or linearity detection was using the default implementation and not using the fact that intervals have no redundancy by construction.
This was hitting another bug with `setvrep!` and `resetvrep!` which are not fixed as well.
Closes https://github.com/JuliaPolyhedra/Polyhedra.jl/issues/298