### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/src/optimization.md
+++ b/docs/src/optimization.md
@@ -114,7 +114,7 @@ See [Polyhedral Function](https://github.com/JuliaPolyhedra/Polyhedra.jl/blob/ma
 ## Creating a polyhedron from the feasible set of a JuMP model
 
 A typical application of polyhedral computation is the computation of the set of extreme points and rays of the feasible set of an optimization problem.
-This comes from the fact that given a minimization of a concave function (or maximization of a convex function) on a convex feasible set (e.g. Linear Programming),
+This comes from the fact that given a minimization of a convex function (or maximization of a concave function) on a convex feasible set (e.g. Linear Programming),
 we are either in the following three situations:
 
 - The feasible set is empty, i.e. the problem is infeasible.

--- a/docs/src/optimization.md
+++ b/docs/src/optimization.md
@@ -19,7 +19,7 @@ Polyhedra.default_solver
 Polyhedra.linear_objective_solver
 ```
 
-## Using a polyhedron for in an optimization model
+## Using a polyhedron in an optimization model
 
 A polyhedron or representation can be used in the constraint of a JuMP model.
 For instance, consider the 1-simplex:


### PR DESCRIPTION
Fix minor typo on concave/convex in docs.

On a side note, this package is awesome. It would be nice to refer to it somewhere in the JuMP.jl docs.