### PR TITLE
Fix inference of iterator mapping

### DIFF
--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -184,8 +184,10 @@ for (isVrep, elt, loop_singular) in [(true, :AbstractVector, :point),
             iterator(T, ElemT, p...)
         end
 
-        function $mapit(f::Function, d::FullDim, ::Type{T}, p::$HorVRep...) where {T}
-            ElemT = promote_type(similar_type.($elemtype.(p), Ref(d), T)...)
+        function $mapit(f::F, d::FullDim, ::Type{T}, p::Vararg{$HorVRep,N}) where {F<:Function,T,N}
+            # On Julia v1.8.3, `$elemtype.(p)` leads to inference failure
+            # but `map($elemtype, p)` works.
+            ElemT = promote_type(similar_type.(map($elemtype, p), Ref(d), T)...)
             iterator(T, ElemT, f, p...)
         end
 


### PR DESCRIPTION
On Julia v1.8.3, we have
```julia
h1 = intersect(HalfSpace(@SVector([1]), 2))
h2 = intersect(HalfSpace([-1], 3))
h = @inferred h1 * h2

# output

julia> include("tmp.jl")
ERROR: LoadError: return type Polyhedra.Intersection{Int64, Vector{Int64}, Int64} does not match inferred return type Rep
```
This PR fixes the issue