### PR TITLE
Fix: Standardize solver error messages for chebyshevcenter

### DIFF
--- a/src/center.jl
+++ b/src/center.jl
@@ -89,11 +89,13 @@ function hchebyshevcenter(p::HRepresentation, solver=default_solver(p; T=Float64
     MOI.set(model, MOI.ObjectiveFunction{MOI.VariableIndex}(), r)
     MOI.optimize!(model)
     term = MOI.get(model, MOI.TerminationStatus())
-    if term ∉ [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
+    if term ∉ [MOI.OPTIMAL, MOI.LOCALLY_SOLVED, MOI.ALMOST_OPTIMAL]
         if term == MOI.INFEASIBLE
             error("An empty polyhedron has no H-Chebyshev center.")
         elseif term == MOI.DUAL_INFEASIBLE
             error("The polyhedron contains a Euclidean ball of arbitrarily large radius.")
+        elseif term == MOI.INFEASIBLE_OR_UNBOUNDED
+            error("The polyhedron is either empty or contains a Euclidean ball of arbitrarily large radius.")
         else
             _unknown_status(model, term, "computing the H-Chebyshev center.")
         end

--- a/test/representation.jl
+++ b/test/representation.jl
@@ -255,10 +255,10 @@ end
 
 function _test_chebyshev_center(::Type{T}) where T
     p = hrep(Matrix(1I, 2, 2), zeros(T, 2))
-    @test_throws ErrorException chebyshevcenter(p, lp_solver) # unbounded
+    @test_throws ErrorException("The polyhedron contains a Euclidean ball of arbitrarily large radius.") chebyshevcenter(p, lp_solver) # unbounded
 
     p = hrep(T[1 1; -1 -1], T[0, -1])
-    @test_throws ErrorException chebyshevcenter(p, lp_solver) # empty
+    @test_throws ErrorException("An empty polyhedron has no H-Chebyshev center.") chebyshevcenter(p, lp_solver) # empty
 
     # examples/chebyshevcenter.ipynb
     A = T[ 2  1


### PR DESCRIPTION
### Description
This PR addresses the inconsistent error messages thrown by different `MathOptInterface` solvers when calculating the `chebyshevcenter` of an empty or unbounded polyhedron. 

Some solvers (like GLPK) explicitly return `DUAL_INFEASIBLE` or `INFEASIBLE`, while others may return `INFEASIBLE_OR_UNBOUNDED` or `ALMOST_OPTIMAL`. Previously, unhandled statuses would fall through to a generic `_unknown_status` crash.

### Changes Made
- Added `MOI.ALMOST_OPTIMAL` to the accepted success statuses for `hchebyshevcenter`.
- Added an explicit catch for `MOI.INFEASIBLE_OR_UNBOUNDED` to prevent generic solver crashes and return a standardized `Polyhedra.jl` error string.
- Updated `test/representation.jl` to assert the specific string expectations for the empty/unbounded edge cases.

Closes #352